### PR TITLE
feat: Debug-Info-Stripping + Float/Double-Obfuscation

### DIFF
--- a/Example/Java Project/src/main/java/example/DebugStrippingDemo.java
+++ b/Example/Java Project/src/main/java/example/DebugStrippingDemo.java
@@ -1,0 +1,38 @@
+package example;
+
+/**
+ * Demo class to visually verify debug info stripping.
+ *
+ * Before obfuscation with debug stripping:
+ *   - Decompiler shows this source file name (e.g. DebugStrippingDemo.java:42)
+ *   - Decompiler shows real line numbers
+ *   - Local variables: userName, userId, processedCount, result, etc.
+ *
+ * After obfuscation WITH debug stripping enabled:
+ *   - Source file / line numbers gone or generic
+ *   - Local variables become: var0, var1, var2, var3...
+ */
+public final class DebugStrippingDemo {
+
+    public void demonstrateLocalVariables() {
+        String userName = "Alice";
+        int userId = 10042;
+        long processedCount = 999_999L;
+        boolean isActive = true;
+        double score = 3.14159;
+
+        String result = userName + " (#" + userId + ") processed=" + processedCount;
+        if (isActive && score > 0) {
+            System.out.println(result);
+        }
+    }
+
+    public int calculateWithManyLocals(int input) {
+        int firstStep = input * 2;
+        int secondStep = firstStep + 100;
+        int thirdStep = secondStep / 3;
+        int finalResult = thirdStep - 7;
+
+        return finalResult;
+    }
+}

--- a/Example/Java Project/src/main/java/example/Main.java
+++ b/Example/Java Project/src/main/java/example/Main.java
@@ -9,6 +9,7 @@ public final class Main {
         System.out.println("Example project running.");
         DemoService service = new DemoService();
         service.run();
+        new DebugStrippingDemo().demonstrateLocalVariables();
         CrossRefTest crossRef = new CrossRefTest();
         crossRef.run();
     }

--- a/Features.md
+++ b/Features.md
@@ -10,11 +10,12 @@
 - **Package flattening** – Inner classes get short names; outer package hierarchy preserved
 
 ### Data Obfuscation
-- **Number obfuscation** – Hides `int` and `long` constants using XOR (`42` → `(42 ^ key) ^ key`)
+- **Number obfuscation** – Hides `int`, `long`, `float` and `double` constants using XOR (`42` → `(42 ^ key) ^ key`; floats/doubles via bit representation)
 - **Array dimension obfuscation** – Hides array sizes (`new int[8]` → `new int[(8 ^ key) ^ key]`)
 - **Boolean obfuscation** – Hides `true`/`false` literals using XOR (`ICONST_0`/`ICONST_1` → `(value ^ key) ^ key`)
 - **String obfuscation** – Encrypts string literals using XOR; decrypts at runtime via injected helper class. Runtime-derived keys for `static final` fields hinder simple decompilers. Strong against `strings`-tools, casual inspection, and basic decompilation. **Note:** Advanced decompilers (e.g. Recaf) can still reconstruct strings via constant propagation and symbolic execution – this cannot be fully prevented with bytecode obfuscation alone.
 - **Optional random keys** – `numberKeyRandom`, `arrayKeyRandom`, `booleanKeyRandom`, `stringKeyRandom` for different XOR keys per build
+- **Debug info stripping** – Removes source file names, line number table, and local variable table. Decompilers show `var0`, `var1`, etc., and lose source mappings. Configurable via `debugInfoStrippingEnabled`.
 
 ### Configuration
 - **YAML config** – `config.yml` next to JAR
@@ -62,7 +63,6 @@
 - **Class merging** – Merge unrelated classes
 - **Fake classes** – Add dummy classes/methods to mislead analysis
 - **Annotation removal** – Strip or obfuscate annotations (configurable)
-- **Debug info stripping** – Remove source file names, line numbers, local variable names
 
 ### Anti-Tampering & Anti-Debugging
 - **Integrity checks** – Detect modification via checksums/hashes

--- a/config.yml.example
+++ b/config.yml.example
@@ -3,7 +3,7 @@
 # Enable or disable class renaming
 classRenamingEnabled: true
 
-# Obfuscate numeric constants (int/long) using XOR
+# Obfuscate numeric constants (int, long, float, double) using XOR
 numberObfuscationEnabled: true
 
 # Obfuscate array dimensions (new Type[n] -> n hidden with XOR)
@@ -14,6 +14,9 @@ booleanObfuscationEnabled: true
 
 # Obfuscate string literals (encrypt at build time, decrypt at runtime)
 stringObfuscationEnabled: true
+
+# Strip debug info (source file, line numbers, local variable names)
+debugInfoStrippingEnabled: true
 
 # Class name generation
 classNamesRandom: false   # true = random names per build, false = sequential (a, b, c...)

--- a/src/main/java/st3ix/obfuscator/config/ConfigLoader.java
+++ b/src/main/java/st3ix/obfuscator/config/ConfigLoader.java
@@ -41,6 +41,7 @@ public final class ConfigLoader {
             boolean arrayObfuscationEnabled = getBoolean(raw, "arrayObfuscationEnabled", true);
             boolean booleanObfuscationEnabled = getBoolean(raw, "booleanObfuscationEnabled", true);
             boolean stringObfuscationEnabled = getBoolean(raw, "stringObfuscationEnabled", true);
+            boolean debugInfoStrippingEnabled = getBoolean(raw, "debugInfoStrippingEnabled", true);
             boolean classNamesRandom = getBoolean(raw, "classNamesRandom", false);
             int classNameLength = getInt(raw, "classNameLength", 6);
             boolean numberKeyRandom = getBoolean(raw, "numberKeyRandom", false);
@@ -51,8 +52,9 @@ public final class ConfigLoader {
 
             return new LoadResult(new ObfuscatorConfig(
                 classRenamingEnabled, numberObfuscationEnabled, arrayObfuscationEnabled,
-                booleanObfuscationEnabled, stringObfuscationEnabled, classNamesRandom, classNameLength,
-                numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, excludeClasses
+                booleanObfuscationEnabled, stringObfuscationEnabled, debugInfoStrippingEnabled,
+                classNamesRandom, classNameLength, numberKeyRandom, arrayKeyRandom,
+                booleanKeyRandom, stringKeyRandom, excludeClasses
             ), configPath);
         } catch (Exception e) {
             return new LoadResult(ObfuscatorConfig.defaults(), null);
@@ -79,6 +81,7 @@ public final class ConfigLoader {
             boolean arrayObfuscationEnabled = getBoolean(raw, "arrayObfuscationEnabled", true);
             boolean booleanObfuscationEnabled = getBoolean(raw, "booleanObfuscationEnabled", true);
             boolean stringObfuscationEnabled = getBoolean(raw, "stringObfuscationEnabled", true);
+            boolean debugInfoStrippingEnabled = getBoolean(raw, "debugInfoStrippingEnabled", true);
             boolean classNamesRandom = getBoolean(raw, "classNamesRandom", false);
             int classNameLength = getInt(raw, "classNameLength", 6);
             boolean numberKeyRandom = getBoolean(raw, "numberKeyRandom", false);
@@ -88,8 +91,9 @@ public final class ConfigLoader {
             List<String> excludeClasses = getStringList(raw, "excludeClasses");
             return new LoadResult(new ObfuscatorConfig(
                 classRenamingEnabled, numberObfuscationEnabled, arrayObfuscationEnabled,
-                booleanObfuscationEnabled, stringObfuscationEnabled, classNamesRandom, classNameLength,
-                numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, excludeClasses
+                booleanObfuscationEnabled, stringObfuscationEnabled, debugInfoStrippingEnabled,
+                classNamesRandom, classNameLength, numberKeyRandom, arrayKeyRandom,
+                booleanKeyRandom, stringKeyRandom, excludeClasses
             ), configPath);
         } catch (Exception e) {
             throw new IOException("Config format invalid: " + e.getMessage());

--- a/src/main/java/st3ix/obfuscator/config/ObfuscatorConfig.java
+++ b/src/main/java/st3ix/obfuscator/config/ObfuscatorConfig.java
@@ -12,6 +12,7 @@ public record ObfuscatorConfig(
     boolean arrayObfuscationEnabled,
     boolean booleanObfuscationEnabled,
     boolean stringObfuscationEnabled,
+    boolean debugInfoStrippingEnabled,
     boolean classNamesRandom,
     int classNameLength,
     boolean numberKeyRandom,
@@ -30,7 +31,7 @@ public record ObfuscatorConfig(
     }
 
     public static ObfuscatorConfig defaults() {
-        return new ObfuscatorConfig(true, true, true, true, true, false, DEFAULT_CLASS_NAME_LENGTH,
+        return new ObfuscatorConfig(true, true, true, true, true, true, false, DEFAULT_CLASS_NAME_LENGTH,
             false, false, false, false, List.of());
     }
 }

--- a/src/main/java/st3ix/obfuscator/core/ObfuscationPipeline.java
+++ b/src/main/java/st3ix/obfuscator/core/ObfuscationPipeline.java
@@ -10,6 +10,7 @@ import st3ix.obfuscator.transform.ArrayObfuscator;
 import st3ix.obfuscator.transform.BooleanObfuscator;
 import st3ix.obfuscator.transform.ClassMapping;
 import st3ix.obfuscator.transform.ClassRenamer;
+import st3ix.obfuscator.transform.DebugInfoStripper;
 import st3ix.obfuscator.transform.NumberObfuscator;
 import st3ix.obfuscator.transform.StringObfuscator;
 
@@ -37,11 +38,13 @@ public final class ObfuscationPipeline {
             Logger.info("Class renaming disabled by config.");
             List<ClassEntry> classesToWrite = contents.classes();
             boolean hasTransforms = config.numberObfuscationEnabled() || config.arrayObfuscationEnabled()
-                || config.booleanObfuscationEnabled() || config.stringObfuscationEnabled();
+                || config.booleanObfuscationEnabled() || config.stringObfuscationEnabled()
+                || config.debugInfoStrippingEnabled();
             if (hasTransforms) {
                 int stepNum = 1;
                 int totalSteps = (config.numberObfuscationEnabled() ? 1 : 0) + (config.arrayObfuscationEnabled() ? 1 : 0)
-                    + (config.booleanObfuscationEnabled() ? 1 : 0) + (config.stringObfuscationEnabled() ? 1 : 0) + 1;
+                    + (config.booleanObfuscationEnabled() ? 1 : 0) + (config.stringObfuscationEnabled() ? 1 : 0)
+                    + (config.debugInfoStrippingEnabled() ? 1 : 0) + 1;
                 if (config.numberObfuscationEnabled()) {
                     Logger.step("Step %d/%d: Number obfuscation", stepNum++, totalSteps);
                     NumberObfuscator no = config.numberKeyRandom() ? NumberObfuscator.withRandomKey() : new NumberObfuscator();
@@ -77,6 +80,14 @@ public final class ObfuscationPipeline {
                     classesToWrite.add(new ClassEntry(StringObfuscator.DECODER_CLASS + ".class", StringObfuscator.DECODER_CLASS, decoderBytes));
                     Logger.success("String obfuscation applied");
                 }
+                if (config.debugInfoStrippingEnabled()) {
+                    Logger.step("Step %d/%d: Debug info stripping", stepNum++, totalSteps);
+                    DebugInfoStripper dis = new DebugInfoStripper();
+                    classesToWrite = classesToWrite.stream()
+                        .map(ce -> new ClassEntry(ce.path(), ce.internalName(), dis.transform(ce.bytes())))
+                        .toList();
+                    Logger.success("Debug info stripping applied");
+                }
                 Logger.step("Step %d/%d: Writing output JAR: %s", stepNum, totalSteps, outputPath);
             } else {
                 Logger.info("Copying JAR without transformations.");
@@ -107,7 +118,9 @@ public final class ObfuscationPipeline {
         boolean arrayObfEnabled = config.arrayObfuscationEnabled();
         boolean booleanObfEnabled = config.booleanObfuscationEnabled();
         boolean stringObfEnabled = config.stringObfuscationEnabled();
-        int totalSteps = 2 + (numberObfEnabled ? 1 : 0) + (arrayObfEnabled ? 1 : 0) + (booleanObfEnabled ? 1 : 0) + (stringObfEnabled ? 1 : 0);
+        boolean debugInfoStrippingEnabled = config.debugInfoStrippingEnabled();
+        int totalSteps = 2 + (numberObfEnabled ? 1 : 0) + (arrayObfEnabled ? 1 : 0) + (booleanObfEnabled ? 1 : 0)
+            + (stringObfEnabled ? 1 : 0) + (debugInfoStrippingEnabled ? 1 : 0);
         int stepNum = 1;
 
         Logger.step("Step %d/%d: Class renaming", stepNum++, totalSteps);
@@ -146,6 +159,9 @@ public final class ObfuscationPipeline {
             if (stringObfEnabled) {
                 bytes = stringObfuscator.transform(bytes);
             }
+            if (debugInfoStrippingEnabled) {
+                bytes = new DebugInfoStripper().transform(bytes);
+            }
             String newPath = newInternal + ".class";
             transformed.add(new ClassEntry(newPath, newInternal, bytes));
         }
@@ -170,6 +186,10 @@ public final class ObfuscationPipeline {
         if (stringObfEnabled) {
             Logger.step("Step %d/%d: String obfuscation", stepNum++, totalSteps);
             Logger.success("String obfuscation applied");
+        }
+        if (debugInfoStrippingEnabled) {
+            Logger.step("Step %d/%d: Debug info stripping", stepNum++, totalSteps);
+            Logger.success("Debug info stripping applied");
         }
 
         Logger.step("Step %d/%d: Writing output JAR: %s", stepNum, totalSteps, outputPath);

--- a/src/main/java/st3ix/obfuscator/gui/ObfuscatorGui.java
+++ b/src/main/java/st3ix/obfuscator/gui/ObfuscatorGui.java
@@ -125,6 +125,7 @@ public final class ObfuscatorGui {
             JCheckBox arrayObf = new JCheckBox("Array obfuscation", true);
             JCheckBox booleanObf = new JCheckBox("Boolean obfuscation", true);
             JCheckBox stringObf = new JCheckBox("String obfuscation", true);
+            JCheckBox debugInfoStrip = new JCheckBox("Strip debug info", true);
             JCheckBox classNamesRandom = new JCheckBox("Random class names", false);
             JCheckBox numberKeyRandom = new JCheckBox("Random number key", false);
             JCheckBox arrayKeyRandom = new JCheckBox("Random array key", false);
@@ -136,6 +137,7 @@ public final class ObfuscatorGui {
             configPanel.add(arrayObf);
             configPanel.add(booleanObf);
             configPanel.add(stringObf);
+            configPanel.add(debugInfoStrip);
             configPanel.add(classNamesRandom);
             configPanel.add(numberKeyRandom);
             configPanel.add(arrayKeyRandom);
@@ -170,7 +172,7 @@ public final class ObfuscatorGui {
                     ToastNotification.show(frame, "No config.yml found next to JAR. Using defaults.", ToastNotification.Type.INFO);
                     return;
                 }
-                applyConfig(classRename, numberObf, arrayObf, booleanObf, stringObf, classNamesRandom,
+                applyConfig(classRename, numberObf, arrayObf, booleanObf, stringObf, debugInfoStrip, classNamesRandom,
                     numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, classNameLength, excludeArea, result.config());
                 ToastNotification.show(frame, "Config loaded.", ToastNotification.Type.SUCCESS);
             });
@@ -182,7 +184,7 @@ public final class ObfuscatorGui {
                 if (fc.showOpenDialog(frame) == JFileChooser.APPROVE_OPTION) {
                     try {
                         var result = ConfigLoader.loadFrom(fc.getSelectedFile().toPath());
-                        applyConfig(classRename, numberObf, arrayObf, booleanObf, stringObf, classNamesRandom,
+                        applyConfig(classRename, numberObf, arrayObf, booleanObf, stringObf, debugInfoStrip, classNamesRandom,
                             numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, classNameLength, excludeArea, result.config());
                         ToastNotification.show(frame, "Config loaded from " + result.configPath().getFileName(), ToastNotification.Type.SUCCESS);
                     } catch (IOException ex) {
@@ -267,6 +269,7 @@ public final class ObfuscatorGui {
                     arrayObf.isSelected(),
                     booleanObf.isSelected(),
                     stringObf.isSelected(),
+                    debugInfoStrip.isSelected(),
                     classNamesRandom.isSelected(),
                     (Integer) classNameLength.getValue(),
                     numberKeyRandom.isSelected(),
@@ -325,14 +328,15 @@ public final class ObfuscatorGui {
     }
 
     private static void applyConfig(JCheckBox classRename, JCheckBox numberObf, JCheckBox arrayObf, JCheckBox booleanObf,
-            JCheckBox stringObf, JCheckBox classNamesRandom, JCheckBox numberKeyRandom, JCheckBox arrayKeyRandom,
-            JCheckBox booleanKeyRandom, JCheckBox stringKeyRandom, JSpinner classNameLength, JTextArea excludeArea,
-            ObfuscatorConfig c) {
+            JCheckBox stringObf, JCheckBox debugInfoStrip, JCheckBox classNamesRandom, JCheckBox numberKeyRandom,
+            JCheckBox arrayKeyRandom, JCheckBox booleanKeyRandom, JCheckBox stringKeyRandom, JSpinner classNameLength,
+            JTextArea excludeArea, ObfuscatorConfig c) {
         classRename.setSelected(c.classRenamingEnabled());
         numberObf.setSelected(c.numberObfuscationEnabled());
         arrayObf.setSelected(c.arrayObfuscationEnabled());
         booleanObf.setSelected(c.booleanObfuscationEnabled());
         stringObf.setSelected(c.stringObfuscationEnabled());
+        debugInfoStrip.setSelected(c.debugInfoStrippingEnabled());
         classNamesRandom.setSelected(c.classNamesRandom());
         numberKeyRandom.setSelected(c.numberKeyRandom());
         arrayKeyRandom.setSelected(c.arrayKeyRandom());

--- a/src/main/java/st3ix/obfuscator/transform/DebugInfoStripper.java
+++ b/src/main/java/st3ix/obfuscator/transform/DebugInfoStripper.java
@@ -1,0 +1,55 @@
+package st3ix.obfuscator.transform;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+/**
+ * Strips debug information from bytecode: source file name, line number table,
+ * and local variable table. Decompilers will show generic variable names (var0, var1, ...)
+ * and lose source-to-bytecode mappings.
+ */
+public final class DebugInfoStripper {
+
+    /**
+     * Transforms the class bytes, removing all debug info.
+     */
+    public byte[] transform(byte[] classBytes) {
+        ClassReader reader = new ClassReader(classBytes);
+        ClassWriter writer = new ClassWriter(reader, ClassWriter.COMPUTE_MAXS);
+        reader.accept(new DebugInfoStripperVisitor(writer), 0);
+        return writer.toByteArray();
+    }
+
+    private static final class DebugInfoStripperVisitor extends ClassVisitor {
+
+        DebugInfoStripperVisitor(ClassVisitor cv) {
+            super(Opcodes.ASM9, cv);
+        }
+
+        @Override
+        public void visitSource(String source, String debug) {
+            // Don't delegate – strips source file and debug extension
+        }
+
+        @Override
+        public MethodVisitor visitMethod(int access, String name, String descriptor,
+                                         String signature, String[] exceptions) {
+            MethodVisitor mv = super.visitMethod(access, name, descriptor, signature, exceptions);
+            return new MethodVisitor(Opcodes.ASM9, mv) {
+                @Override
+                public void visitLineNumber(int line, org.objectweb.asm.Label start) {
+                    // Don't delegate – strips line number table
+                }
+
+                @Override
+                public void visitLocalVariable(String name, String descriptor, String signature,
+                                               org.objectweb.asm.Label start, org.objectweb.asm.Label end, int index) {
+                    // Don't delegate – strips local variable table
+                }
+            };
+        }
+    }
+}

--- a/src/main/java/st3ix/obfuscator/transform/NumberObfuscator.java
+++ b/src/main/java/st3ix/obfuscator/transform/NumberObfuscator.java
@@ -9,8 +9,9 @@ import org.objectweb.asm.Opcodes;
 import java.util.Random;
 
 /**
- * Obfuscates integer and long constants in bytecode using XOR.
+ * Obfuscates integer, long, float and double constants in bytecode using XOR.
  * Replaces ldc N with (N ^ key) ^ key to hide the original value.
+ * For float/double, the bit representation is XORed and reconstructed at runtime.
  */
 public final class NumberObfuscator {
 
@@ -97,13 +98,31 @@ public final class NumberObfuscator {
             if (value instanceof Integer i) {
                 emitXorInt(i);
             } else if (value instanceof Long l) {
-                long obfuscated = l ^ longKey;
+                emitXorLong(l);
+            } else if (value instanceof Float f) {
+                int bits = Float.floatToRawIntBits(f);
+                int obfuscated = bits ^ intKey;
+                super.visitLdcInsn(obfuscated);
+                super.visitLdcInsn(intKey);
+                super.visitInsn(Opcodes.IXOR);
+                super.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Float", "intBitsToFloat", "(I)F", false);
+            } else if (value instanceof Double d) {
+                long bits = Double.doubleToRawLongBits(d);
+                long obfuscated = bits ^ longKey;
                 super.visitLdcInsn(obfuscated);
                 super.visitLdcInsn(longKey);
                 super.visitInsn(Opcodes.LXOR);
+                super.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Double", "longBitsToDouble", "(J)D", false);
             } else {
                 super.visitLdcInsn(value);
             }
+        }
+
+        private void emitXorLong(long value) {
+            long obfuscated = value ^ longKey;
+            super.visitLdcInsn(obfuscated);
+            super.visitLdcInsn(longKey);
+            super.visitInsn(Opcodes.LXOR);
         }
 
         private void emitXorInt(int value) {


### PR DESCRIPTION
## Summary

- **Debug info stripping:** Removes source file name, line numbers, and local variable names
- **Number obfuscation:** Extends support to `float` and `double` literals

## Changes

### Debug info stripping
- New transformer `DebugInfoStripper.java` (removes source, LineNumberTable, LocalVariableTable)
- Config option `debugInfoStrippingEnabled` (default: `true`)
- GUI checkbox "Strip debug info"

### Number obfuscation
- `float` and `double` obfuscated via XOR of bit representation
- Uses `Float.intBitsToFloat()` and `Double.longBitsToDouble()` at runtime

### Example project
- Added `DebugStrippingDemo.java` to illustrate the effects

## Modified files

- `DebugInfoStripper.java` (new)
- `NumberObfuscator.java` (float/double support)
- `ObfuscatorConfig`, `ConfigLoader`, `ObfuscationPipeline`, `ObfuscatorGui`
- `config.yml.example`, `Features.md`
- Example: `DebugStrippingDemo.java`, `Main.java`