### PR TITLE
feat: Homoglyph & invisible character obfuscation for class names

### DIFF
--- a/Features.md
+++ b/Features.md
@@ -8,6 +8,8 @@
 - **Random vs sequential** – Optional random names per build for stronger obfuscation
 - **Exclude patterns** – Skip classes/packages from renaming (config + built-in for JDK, Bukkit, Minecraft, etc.)
 - **Package flattening** – Inner classes get short names; outer package hierarchy preserved
+- **Homoglyph obfuscation** – Use Unicode lookalikes (e.g. Cyrillic а instead of Latin a). Names appear familiar but copy-paste and search fail. Sequential: fixed mapping; random: varies per char.
+- **Invisible character injection** – Zero-width chars (U+200B, etc.) in names. Safe for JVM; harder to detect and remove.
 
 ### Data Obfuscation
 - **Number obfuscation** – Hides `int`, `long`, `float` and `double` constants using XOR (`42` → `(42 ^ key) ^ key`; floats/doubles via bit representation)

--- a/config.yml.example
+++ b/config.yml.example
@@ -21,6 +21,8 @@ debugInfoStrippingEnabled: true
 # Class name generation
 classNamesRandom: false   # true = random names per build, false = sequential (a, b, c...)
 classNameLength: 6       # minimum length of class names (1-32). Longer = harder to read.
+classNamesHomoglyph: false   # use lookalike chars (Cyrillic а vs Latin a); copy-paste fails
+classNamesInvisibleChars: false  # inject zero-width chars; names appear normal but differ
 
 # Obfuscation keys (XOR)
 numberKeyRandom: false   # true = random key per build, false = fixed key

--- a/src/main/java/st3ix/obfuscator/config/ConfigLoader.java
+++ b/src/main/java/st3ix/obfuscator/config/ConfigLoader.java
@@ -44,6 +44,8 @@ public final class ConfigLoader {
             boolean debugInfoStrippingEnabled = getBoolean(raw, "debugInfoStrippingEnabled", true);
             boolean classNamesRandom = getBoolean(raw, "classNamesRandom", false);
             int classNameLength = getInt(raw, "classNameLength", 6);
+            boolean classNamesHomoglyph = getBoolean(raw, "classNamesHomoglyph", false);
+            boolean classNamesInvisibleChars = getBoolean(raw, "classNamesInvisibleChars", false);
             boolean numberKeyRandom = getBoolean(raw, "numberKeyRandom", false);
             boolean arrayKeyRandom = getBoolean(raw, "arrayKeyRandom", false);
             boolean booleanKeyRandom = getBoolean(raw, "booleanKeyRandom", false);
@@ -53,8 +55,8 @@ public final class ConfigLoader {
             return new LoadResult(new ObfuscatorConfig(
                 classRenamingEnabled, numberObfuscationEnabled, arrayObfuscationEnabled,
                 booleanObfuscationEnabled, stringObfuscationEnabled, debugInfoStrippingEnabled,
-                classNamesRandom, classNameLength, numberKeyRandom, arrayKeyRandom,
-                booleanKeyRandom, stringKeyRandom, excludeClasses
+                classNamesRandom, classNameLength, classNamesHomoglyph, classNamesInvisibleChars,
+                numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, excludeClasses
             ), configPath);
         } catch (Exception e) {
             return new LoadResult(ObfuscatorConfig.defaults(), null);
@@ -84,6 +86,8 @@ public final class ConfigLoader {
             boolean debugInfoStrippingEnabled = getBoolean(raw, "debugInfoStrippingEnabled", true);
             boolean classNamesRandom = getBoolean(raw, "classNamesRandom", false);
             int classNameLength = getInt(raw, "classNameLength", 6);
+            boolean classNamesHomoglyph = getBoolean(raw, "classNamesHomoglyph", false);
+            boolean classNamesInvisibleChars = getBoolean(raw, "classNamesInvisibleChars", false);
             boolean numberKeyRandom = getBoolean(raw, "numberKeyRandom", false);
             boolean arrayKeyRandom = getBoolean(raw, "arrayKeyRandom", false);
             boolean booleanKeyRandom = getBoolean(raw, "booleanKeyRandom", false);
@@ -92,8 +96,8 @@ public final class ConfigLoader {
             return new LoadResult(new ObfuscatorConfig(
                 classRenamingEnabled, numberObfuscationEnabled, arrayObfuscationEnabled,
                 booleanObfuscationEnabled, stringObfuscationEnabled, debugInfoStrippingEnabled,
-                classNamesRandom, classNameLength, numberKeyRandom, arrayKeyRandom,
-                booleanKeyRandom, stringKeyRandom, excludeClasses
+                classNamesRandom, classNameLength, classNamesHomoglyph, classNamesInvisibleChars,
+                numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, excludeClasses
             ), configPath);
         } catch (Exception e) {
             throw new IOException("Config format invalid: " + e.getMessage());

--- a/src/main/java/st3ix/obfuscator/config/ObfuscatorConfig.java
+++ b/src/main/java/st3ix/obfuscator/config/ObfuscatorConfig.java
@@ -15,6 +15,8 @@ public record ObfuscatorConfig(
     boolean debugInfoStrippingEnabled,
     boolean classNamesRandom,
     int classNameLength,
+    boolean classNamesHomoglyph,
+    boolean classNamesInvisibleChars,
     boolean numberKeyRandom,
     boolean arrayKeyRandom,
     boolean booleanKeyRandom,
@@ -32,6 +34,6 @@ public record ObfuscatorConfig(
 
     public static ObfuscatorConfig defaults() {
         return new ObfuscatorConfig(true, true, true, true, true, true, false, DEFAULT_CLASS_NAME_LENGTH,
-            false, false, false, false, List.of());
+            false, false, false, false, false, false, List.of());
     }
 }

--- a/src/main/java/st3ix/obfuscator/core/ObfuscationPipeline.java
+++ b/src/main/java/st3ix/obfuscator/core/ObfuscationPipeline.java
@@ -108,7 +108,8 @@ public final class ObfuscationPipeline {
             .toList();
 
         Logger.info("Building class mapping (%d classes)", classNames.size());
-        ClassMapping mapping = new ClassMapping(config.classNamesRandom(), config.classNameLength());
+        ClassMapping mapping = new ClassMapping(config.classNamesRandom(), config.classNameLength(),
+            config.classNamesHomoglyph(), config.classNamesInvisibleChars());
         mapping.addExcludes(config.excludeClasses());
         for (String name : classNames) {
             mapping.map(name);

--- a/src/main/java/st3ix/obfuscator/gui/ObfuscatorGui.java
+++ b/src/main/java/st3ix/obfuscator/gui/ObfuscatorGui.java
@@ -127,6 +127,8 @@ public final class ObfuscatorGui {
             JCheckBox stringObf = new JCheckBox("String obfuscation", true);
             JCheckBox debugInfoStrip = new JCheckBox("Strip debug info", true);
             JCheckBox classNamesRandom = new JCheckBox("Random class names", false);
+            JCheckBox classNamesHomoglyph = new JCheckBox("Homoglyph class names", false);
+            JCheckBox classNamesInvisibleChars = new JCheckBox("Invisible chars in names", false);
             JCheckBox numberKeyRandom = new JCheckBox("Random number key", false);
             JCheckBox arrayKeyRandom = new JCheckBox("Random array key", false);
             JCheckBox booleanKeyRandom = new JCheckBox("Random boolean key", false);
@@ -139,6 +141,8 @@ public final class ObfuscatorGui {
             configPanel.add(stringObf);
             configPanel.add(debugInfoStrip);
             configPanel.add(classNamesRandom);
+            configPanel.add(classNamesHomoglyph);
+            configPanel.add(classNamesInvisibleChars);
             configPanel.add(numberKeyRandom);
             configPanel.add(arrayKeyRandom);
             configPanel.add(booleanKeyRandom);
@@ -147,6 +151,16 @@ public final class ObfuscatorGui {
             configPanel.add(classNameLength);
             center.add(configPanel, BorderLayout.NORTH);
 
+            JPanel advancedObfPanel = new JPanel(new BorderLayout(4, 4));
+            advancedObfPanel.setBackground(BG_PANEL);
+            advancedObfPanel.setBorder(BorderFactory.createTitledBorder(new LineBorder(BORDER, 1), "Advanced class name obfuscation"));
+            String homoglyphInfo = "<html><b>Homoglyphs & invisible characters</b> – Use Unicode lookalikes (e.g. Cyrillic а instead of Latin a) and zero-width chars. "
+                + "Names appear normal but copy-paste and search fail. Safe for JVM; increases reverse-engineering effort.</html>";
+            JLabel homoglyphInfoLabel = new JLabel(homoglyphInfo);
+            homoglyphInfoLabel.setFont(homoglyphInfoLabel.getFont().deriveFont(10f));
+            homoglyphInfoLabel.setForeground(new Color(0x555555));
+            homoglyphInfoLabel.setBorder(new EmptyBorder(4, 6, 8, 6));
+            advancedObfPanel.add(homoglyphInfoLabel, BorderLayout.NORTH);
             JPanel excludePanel = new JPanel(new BorderLayout(4, 4));
             excludePanel.setBackground(BG_PANEL);
             excludePanel.setBorder(BorderFactory.createTitledBorder(new LineBorder(BORDER, 1), "Exclude classes (one per line)"));
@@ -160,7 +174,13 @@ public final class ObfuscatorGui {
             excludeInfo.setForeground(new Color(0x666666));
             excludePanel.add(excludeScroll, BorderLayout.CENTER);
             excludePanel.add(excludeInfo, BorderLayout.SOUTH);
-            center.add(excludePanel, BorderLayout.CENTER);
+
+            JPanel centerContent = new JPanel();
+            centerContent.setLayout(new BoxLayout(centerContent, BoxLayout.Y_AXIS));
+            centerContent.setBackground(BG_MAIN);
+            centerContent.add(advancedObfPanel);
+            centerContent.add(excludePanel);
+            center.add(centerContent, BorderLayout.CENTER);
 
             JPanel configRow = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 4));
             configRow.setBackground(BG_MAIN);
@@ -173,7 +193,8 @@ public final class ObfuscatorGui {
                     return;
                 }
                 applyConfig(classRename, numberObf, arrayObf, booleanObf, stringObf, debugInfoStrip, classNamesRandom,
-                    numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, classNameLength, excludeArea, result.config());
+                    classNamesHomoglyph, classNamesInvisibleChars, numberKeyRandom, arrayKeyRandom, booleanKeyRandom,
+                    stringKeyRandom, classNameLength, excludeArea, result.config());
                 ToastNotification.show(frame, "Config loaded.", ToastNotification.Type.SUCCESS);
             });
             JButton browseConfigBtn = new JButton("Browse config...");
@@ -185,7 +206,8 @@ public final class ObfuscatorGui {
                     try {
                         var result = ConfigLoader.loadFrom(fc.getSelectedFile().toPath());
                         applyConfig(classRename, numberObf, arrayObf, booleanObf, stringObf, debugInfoStrip, classNamesRandom,
-                            numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, classNameLength, excludeArea, result.config());
+                            classNamesHomoglyph, classNamesInvisibleChars, numberKeyRandom, arrayKeyRandom, booleanKeyRandom,
+                            stringKeyRandom, classNameLength, excludeArea, result.config());
                         ToastNotification.show(frame, "Config loaded from " + result.configPath().getFileName(), ToastNotification.Type.SUCCESS);
                     } catch (IOException ex) {
                         ToastNotification.show(frame, "Config invalid: " + ex.getMessage(), ToastNotification.Type.ERROR);
@@ -272,6 +294,8 @@ public final class ObfuscatorGui {
                     debugInfoStrip.isSelected(),
                     classNamesRandom.isSelected(),
                     (Integer) classNameLength.getValue(),
+                    classNamesHomoglyph.isSelected(),
+                    classNamesInvisibleChars.isSelected(),
                     numberKeyRandom.isSelected(),
                     arrayKeyRandom.isSelected(),
                     booleanKeyRandom.isSelected(),
@@ -328,9 +352,10 @@ public final class ObfuscatorGui {
     }
 
     private static void applyConfig(JCheckBox classRename, JCheckBox numberObf, JCheckBox arrayObf, JCheckBox booleanObf,
-            JCheckBox stringObf, JCheckBox debugInfoStrip, JCheckBox classNamesRandom, JCheckBox numberKeyRandom,
-            JCheckBox arrayKeyRandom, JCheckBox booleanKeyRandom, JCheckBox stringKeyRandom, JSpinner classNameLength,
-            JTextArea excludeArea, ObfuscatorConfig c) {
+            JCheckBox stringObf, JCheckBox debugInfoStrip, JCheckBox classNamesRandom, JCheckBox classNamesHomoglyph,
+            JCheckBox classNamesInvisibleChars, JCheckBox numberKeyRandom, JCheckBox arrayKeyRandom,
+            JCheckBox booleanKeyRandom, JCheckBox stringKeyRandom, JSpinner classNameLength, JTextArea excludeArea,
+            ObfuscatorConfig c) {
         classRename.setSelected(c.classRenamingEnabled());
         numberObf.setSelected(c.numberObfuscationEnabled());
         arrayObf.setSelected(c.arrayObfuscationEnabled());
@@ -338,6 +363,8 @@ public final class ObfuscatorGui {
         stringObf.setSelected(c.stringObfuscationEnabled());
         debugInfoStrip.setSelected(c.debugInfoStrippingEnabled());
         classNamesRandom.setSelected(c.classNamesRandom());
+        classNamesHomoglyph.setSelected(c.classNamesHomoglyph());
+        classNamesInvisibleChars.setSelected(c.classNamesInvisibleChars());
         numberKeyRandom.setSelected(c.numberKeyRandom());
         arrayKeyRandom.setSelected(c.arrayKeyRandom());
         booleanKeyRandom.setSelected(c.booleanKeyRandom());

--- a/src/main/java/st3ix/obfuscator/transform/ClassMapping.java
+++ b/src/main/java/st3ix/obfuscator/transform/ClassMapping.java
@@ -37,7 +37,14 @@ public final class ClassMapping {
      * @param nameLength minimum length of generated names (1–32)
      */
     public ClassMapping(boolean namesRandom, int nameLength) {
-        this.nameGen = new NameGenerator(namesRandom, nameLength);
+        this(namesRandom, nameLength, false, false);
+    }
+
+    /**
+     * Creates a mapping with optional homoglyph and invisible-char obfuscation.
+     */
+    public ClassMapping(boolean namesRandom, int nameLength, boolean useHomoglyph, boolean useInvisibleChars) {
+        this.nameGen = new NameGenerator(namesRandom, nameLength, useHomoglyph, useInvisibleChars);
         for (String p : LIBRARY_PREFIXES) {
             excludePrefixes.add(p);
         }

--- a/src/main/java/st3ix/obfuscator/transform/NameGenerator.java
+++ b/src/main/java/st3ix/obfuscator/transform/NameGenerator.java
@@ -10,22 +10,39 @@ import java.util.Set;
  * Generates unique identifiers for obfuscation.
  * Sequential mode: a, b, ..., z, aa, ab, ... (optionally with minimum length).
  * Random mode: random strings of configured length (e.g. xK9mP2).
+ * Optional: homoglyphs (lookalike Unicode chars) and invisible (zero-width) chars for stronger obfuscation.
  */
 public final class NameGenerator {
 
     private static final String CHARS = "abcdefghijklmnopqrstuvwxyz";
+    /** Latin a-z -> Cyrillic lookalike (а,с,е,о,р,х,у); others unchanged */
+    private static final String HOMOGLYPH_CHARS = "\u0430b\u0441d\u0435fghijklmn\u043E\u043Fqrstuvw\u0445\u0443z";
+    /** Zero-width & narrow invisible chars: 200B–200F, 2060, 200A, 202F */
+    private static final char[] INVISIBLE_CHARS = {
+        '\u200B', /* Zero-Width Space */
+        '\u200C', /* Zero Width Non-Joiner */
+        '\u200D', /* Zero Width Joiner */
+        '\u200E', /* Left-To-Right Mark */
+        '\u200F', /* Right-To-Left Mark */
+        '\u2060', /* Word Joiner */
+        '\u200A', /* Hair Space */
+        '\u202F', /* Narrow No-Break Space */
+    };
+
     private final int minLength;
     private final boolean random;
+    private final boolean useHomoglyph;
+    private final boolean useInvisibleChars;
     private final Random rng;
     private final Set<String> usedRandom = new HashSet<>();
     private final List<String> generated = new ArrayList<>();
     private int index;
 
     /**
-     * Creates a generator with default behavior (sequential, length 1).
+     * Creates a generator with default behavior (sequential, length 1, no homoglyph/invisible).
      */
     public NameGenerator() {
-        this(false, 1);
+        this(false, 1, false, false);
     }
 
     /**
@@ -35,8 +52,22 @@ public final class NameGenerator {
      * @param minLength minimum name length (1–32). Sequential uses this as minimum; random uses exact length.
      */
     public NameGenerator(boolean random, int minLength) {
+        this(random, minLength, false, false);
+    }
+
+    /**
+     * Creates a generator with optional homoglyph and invisible-char obfuscation.
+     *
+     * @param random true for random names, false for sequential
+     * @param minLength minimum name length (1–32)
+     * @param useHomoglyph use lookalike chars (a→а, e→е, etc.). Sequential: fixed mapping; Random: varies per char
+     * @param useInvisibleChars inject zero-width chars. Sequential: fixed append; Random: random position
+     */
+    public NameGenerator(boolean random, int minLength, boolean useHomoglyph, boolean useInvisibleChars) {
         this.random = random;
         this.minLength = Math.max(1, Math.min(32, minLength));
+        this.useHomoglyph = useHomoglyph;
+        this.useInvisibleChars = useInvisibleChars;
         this.rng = new Random();
     }
 
@@ -44,7 +75,9 @@ public final class NameGenerator {
      * Returns the next unique name.
      */
     public String next() {
-        String name = random ? nextRandom() : nextSequential();
+        String base = random ? nextRandom() : nextSequential();
+        String name = applyHomoglyph(base);
+        name = applyInvisibleChars(name);
         generated.add(name);
         return name;
     }
@@ -100,5 +133,38 @@ public final class NameGenerator {
         String fallback = "n" + rng.nextInt(1_000_000);
         usedRandom.add(fallback);
         return fallback;
+    }
+
+    private String applyHomoglyph(String s) {
+        if (!useHomoglyph) return s;
+        StringBuilder sb = new StringBuilder(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            int idx = c - 'a';
+            if (random && idx >= 0 && idx < HOMOGLYPH_CHARS.length()) {
+                char homoglyph = HOMOGLYPH_CHARS.charAt(idx);
+                if (homoglyph != c) {
+                    sb.append(rng.nextBoolean() ? homoglyph : c);
+                } else {
+                    sb.append(c);
+                }
+            } else if (!random && idx >= 0 && idx < HOMOGLYPH_CHARS.length()) {
+                sb.append(HOMOGLYPH_CHARS.charAt(idx));
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+
+    private String applyInvisibleChars(String s) {
+        if (!useInvisibleChars) return s;
+        if (random) {
+            int pos = rng.nextInt(s.length() + 1);
+            char inv = INVISIBLE_CHARS[rng.nextInt(INVISIBLE_CHARS.length)];
+            return s.substring(0, pos) + inv + s.substring(pos);
+        } else {
+            return s + INVISIBLE_CHARS[0];
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds optional homoglyph and invisible character obfuscation to class names, so decompiled identifiers look familiar but copy-paste and text search fail.

## Changes

### Homoglyphs
- Use Cyrillic lookalikes (а, с, е, о, р, х, у) instead of Latin letters
- Sequential mode: fixed mapping
- Random mode: varies per character

### Invisible Characters
- Insert zero-width and narrow chars (U+200B, 200C, 200D, 200E, 200F, 2060, 200A, 202F)
- Sequential mode: append one at the end
- Random mode: random position

### Config & GUI
- `classNamesHomoglyph`
- `classNamesInvisibleChars`
- GUI checkboxes with short info text on safety and effects

## Modified Files

- `NameGenerator.java` – homoglyph mapping, invisible char pool
- `ClassMapping.java` – optional homoglyph/invisible params
- `ObfuscatorConfig`, `ConfigLoader`, `ObfuscationPipeline`
- `ObfuscatorGui.java` – checkboxes and info panel
- `config.yml.example`, `Features.md`