### PR TITLE
feat: support "*" in exclude classes

### DIFF
--- a/Features.md
+++ b/Features.md
@@ -6,7 +6,7 @@
 - **Class renaming** – Renames classes to short or random identifiers (e.g. `a`, `b`, `c` or `xk9m2p`)
 - **Configurable name length** – Minimum length 1–32 characters
 - **Random vs sequential** – Optional random names per build for stronger obfuscation
-- **Exclude patterns** – Skip classes/packages from renaming (config + built-in for JDK, Bukkit, Minecraft, etc.)
+- **Exclude patterns** – Skip classes/packages from renaming. Use `*` to exclude all classes; prefix matches (e.g. `com.example` excludes `com.example.*`). Built-in: java.*, javax.*, Bukkit, Minecraft, etc.
 - **Package flattening** – Inner classes get short names; outer package hierarchy preserved
 - **Homoglyph obfuscation** – Use Unicode lookalikes (e.g. Cyrillic а instead of Latin a). Names appear familiar but copy-paste and search fail. Sequential: fixed mapping; random: varies per char.
 - **Invisible character injection** – Zero-width chars (U+200B, etc.) in names. Safe for JVM; harder to detect and remove.

--- a/config.yml.example
+++ b/config.yml.example
@@ -31,8 +31,8 @@ booleanKeyRandom: false  # true = random key per build, false = fixed key
 stringKeyRandom: false   # true = random key per build, false = fixed key
 
 # Classes/packages to exclude from renaming.
-# Use dot or slash notation. Prefix matches (org.bukkit excludes org.bukkit.*)
-# Built-in excludes: java.*, javax.*, org.bukkit.*, net.minecraft.*, org.spigotmc.*, etc.
+# Use "*" to exclude ALL classes (no renaming). Prefix: com.example excludes com.example.*
+# Built-in excludes: java.*, javax.*, org.bukkit.*, net.minecraft.*, etc.
 excludeClasses:
   - com.myapp.sensitive
   - org.example.api

--- a/src/main/java/st3ix/obfuscator/transform/ClassMapping.java
+++ b/src/main/java/st3ix/obfuscator/transform/ClassMapping.java
@@ -25,6 +25,7 @@ public final class ClassMapping {
     private final List<String> excludePrefixes = new ArrayList<>();
     private final Map<String, String> oldToNew = new HashMap<>();
     private final NameGenerator nameGen;
+    private boolean excludeAll;
 
     public ClassMapping() {
         this(false, 1);
@@ -52,12 +53,19 @@ public final class ClassMapping {
 
     /**
      * Adds exclude patterns from config. Accepts dot or slash notation (e.g. org.bukkit or org/bukkit).
+     * Use "*" to exclude all classes from renaming.
      */
     public void addExcludes(List<String> patterns) {
         if (patterns == null) return;
         for (String p : patterns) {
             if (p == null || p.isBlank()) continue;
-            String internal = p.trim().replace('.', '/');
+            String trimmed = p.trim();
+            if ("*".equals(trimmed)) {
+                excludeAll = true;
+                return;
+            }
+            String internal = trimmed.replace('.', '/');
+            if (internal.endsWith("/*")) internal = internal.substring(0, internal.length() - 1);
             if (!internal.endsWith("/")) internal += "/";
             excludePrefixes.add(internal);
         }
@@ -73,7 +81,7 @@ public final class ClassMapping {
         if (oldToNew.containsKey(internalName)) {
             return oldToNew.get(internalName);
         }
-        if (isExcluded(internalName)) {
+        if (excludeAll || isExcluded(internalName)) {
             oldToNew.put(internalName, internalName);
             return internalName;
         }


### PR DESCRIPTION
## Summary

Add support for `*` in exclude classes so that all classes can be excluded from renaming.

## Changes

- `*` alone: exclude all classes (no class renaming)
- `com.example.*`: prefix match as before (`com.example` + subpackages)
- Config and GUI both support the new pattern

## Modified Files
- `ClassMapping.java` – `excludeAll` flag and `*` handling
- `config.yml.example` – documented `*`
- `Features.md` – updated exclude docs

Closes #24 