### PR TITLE
feat: add method renaming with config, GUI, and rename logging

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -3,6 +3,9 @@
 # Enable or disable class renaming
 classRenamingEnabled: true
 
+# Enable or disable method renaming (excludes constructors, main, native, enum methods)
+methodRenamingEnabled: true
+
 # Obfuscate numeric constants (int, long, float, double) using XOR
 numberObfuscationEnabled: true
 
@@ -23,6 +26,12 @@ classNamesRandom: false   # true = random names per build, false = sequential (a
 classNameLength: 6       # minimum length of class names (1-32). Longer = harder to read.
 classNamesHomoglyph: false   # use lookalike chars (Cyrillic а vs Latin a); copy-paste fails
 classNamesInvisibleChars: false  # inject zero-width chars; names appear normal but differ
+
+# Method name generation
+methodNamesRandom: false   # true = random method names per build, false = sequential
+methodNameLength: 4        # minimum length of method names (1-32)
+methodNamesHomoglyph: false   # use lookalike chars for method names
+methodNamesInvisibleChars: false  # inject zero-width chars in method names
 
 # Obfuscation keys (XOR)
 numberKeyRandom: false   # true = random key per build, false = fixed key

--- a/src/main/java/st3ix/obfuscator/config/ConfigLoader.java
+++ b/src/main/java/st3ix/obfuscator/config/ConfigLoader.java
@@ -37,6 +37,7 @@ public final class ConfigLoader {
             if (raw == null) return new LoadResult(ObfuscatorConfig.defaults(), null);
 
             boolean classRenamingEnabled = getBoolean(raw, "classRenamingEnabled", true);
+            boolean methodRenamingEnabled = getBoolean(raw, "methodRenamingEnabled", true);
             boolean numberObfuscationEnabled = getBoolean(raw, "numberObfuscationEnabled", true);
             boolean arrayObfuscationEnabled = getBoolean(raw, "arrayObfuscationEnabled", true);
             boolean booleanObfuscationEnabled = getBoolean(raw, "booleanObfuscationEnabled", true);
@@ -46,6 +47,10 @@ public final class ConfigLoader {
             int classNameLength = getInt(raw, "classNameLength", 6);
             boolean classNamesHomoglyph = getBoolean(raw, "classNamesHomoglyph", false);
             boolean classNamesInvisibleChars = getBoolean(raw, "classNamesInvisibleChars", false);
+            boolean methodNamesRandom = getBoolean(raw, "methodNamesRandom", false);
+            int methodNameLength = getInt(raw, "methodNameLength", 4);
+            boolean methodNamesHomoglyph = getBoolean(raw, "methodNamesHomoglyph", false);
+            boolean methodNamesInvisibleChars = getBoolean(raw, "methodNamesInvisibleChars", false);
             boolean numberKeyRandom = getBoolean(raw, "numberKeyRandom", false);
             boolean arrayKeyRandom = getBoolean(raw, "arrayKeyRandom", false);
             boolean booleanKeyRandom = getBoolean(raw, "booleanKeyRandom", false);
@@ -53,9 +58,10 @@ public final class ConfigLoader {
             List<String> excludeClasses = getStringList(raw, "excludeClasses");
 
             return new LoadResult(new ObfuscatorConfig(
-                classRenamingEnabled, numberObfuscationEnabled, arrayObfuscationEnabled,
+                classRenamingEnabled, methodRenamingEnabled, numberObfuscationEnabled, arrayObfuscationEnabled,
                 booleanObfuscationEnabled, stringObfuscationEnabled, debugInfoStrippingEnabled,
                 classNamesRandom, classNameLength, classNamesHomoglyph, classNamesInvisibleChars,
+                methodNamesRandom, methodNameLength, methodNamesHomoglyph, methodNamesInvisibleChars,
                 numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, excludeClasses
             ), configPath);
         } catch (Exception e) {
@@ -79,6 +85,7 @@ public final class ConfigLoader {
         }
         try {
             boolean classRenamingEnabled = getBoolean(raw, "classRenamingEnabled", true);
+            boolean methodRenamingEnabled = getBoolean(raw, "methodRenamingEnabled", true);
             boolean numberObfuscationEnabled = getBoolean(raw, "numberObfuscationEnabled", true);
             boolean arrayObfuscationEnabled = getBoolean(raw, "arrayObfuscationEnabled", true);
             boolean booleanObfuscationEnabled = getBoolean(raw, "booleanObfuscationEnabled", true);
@@ -88,15 +95,20 @@ public final class ConfigLoader {
             int classNameLength = getInt(raw, "classNameLength", 6);
             boolean classNamesHomoglyph = getBoolean(raw, "classNamesHomoglyph", false);
             boolean classNamesInvisibleChars = getBoolean(raw, "classNamesInvisibleChars", false);
+            boolean methodNamesRandom = getBoolean(raw, "methodNamesRandom", false);
+            int methodNameLength = getInt(raw, "methodNameLength", 4);
+            boolean methodNamesHomoglyph = getBoolean(raw, "methodNamesHomoglyph", false);
+            boolean methodNamesInvisibleChars = getBoolean(raw, "methodNamesInvisibleChars", false);
             boolean numberKeyRandom = getBoolean(raw, "numberKeyRandom", false);
             boolean arrayKeyRandom = getBoolean(raw, "arrayKeyRandom", false);
             boolean booleanKeyRandom = getBoolean(raw, "booleanKeyRandom", false);
             boolean stringKeyRandom = getBoolean(raw, "stringKeyRandom", false);
             List<String> excludeClasses = getStringList(raw, "excludeClasses");
             return new LoadResult(new ObfuscatorConfig(
-                classRenamingEnabled, numberObfuscationEnabled, arrayObfuscationEnabled,
+                classRenamingEnabled, methodRenamingEnabled, numberObfuscationEnabled, arrayObfuscationEnabled,
                 booleanObfuscationEnabled, stringObfuscationEnabled, debugInfoStrippingEnabled,
                 classNamesRandom, classNameLength, classNamesHomoglyph, classNamesInvisibleChars,
+                methodNamesRandom, methodNameLength, methodNamesHomoglyph, methodNamesInvisibleChars,
                 numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, excludeClasses
             ), configPath);
         } catch (Exception e) {

--- a/src/main/java/st3ix/obfuscator/config/ObfuscatorConfig.java
+++ b/src/main/java/st3ix/obfuscator/config/ObfuscatorConfig.java
@@ -8,6 +8,7 @@ import java.util.List;
  */
 public record ObfuscatorConfig(
     boolean classRenamingEnabled,
+    boolean methodRenamingEnabled,
     boolean numberObfuscationEnabled,
     boolean arrayObfuscationEnabled,
     boolean booleanObfuscationEnabled,
@@ -17,6 +18,10 @@ public record ObfuscatorConfig(
     int classNameLength,
     boolean classNamesHomoglyph,
     boolean classNamesInvisibleChars,
+    boolean methodNamesRandom,
+    int methodNameLength,
+    boolean methodNamesHomoglyph,
+    boolean methodNamesInvisibleChars,
     boolean numberKeyRandom,
     boolean arrayKeyRandom,
     boolean booleanKeyRandom,
@@ -24,16 +29,21 @@ public record ObfuscatorConfig(
     List<String> excludeClasses
 ) {
     private static final int DEFAULT_CLASS_NAME_LENGTH = 6;
-    private static final int MIN_CLASS_NAME_LENGTH = 1;
+    private static final int DEFAULT_METHOD_NAME_LENGTH = 4;
+    private static final int MIN_NAME_LENGTH = 1;
     private static final int MAX_CLASS_NAME_LENGTH = 32;
+    private static final int MAX_METHOD_NAME_LENGTH = 32;
 
     public ObfuscatorConfig {
         excludeClasses = excludeClasses != null ? List.copyOf(excludeClasses) : Collections.emptyList();
-        classNameLength = Math.max(MIN_CLASS_NAME_LENGTH, Math.min(MAX_CLASS_NAME_LENGTH, classNameLength));
+        classNameLength = Math.max(MIN_NAME_LENGTH, Math.min(MAX_CLASS_NAME_LENGTH, classNameLength));
+        methodNameLength = Math.max(MIN_NAME_LENGTH, Math.min(MAX_METHOD_NAME_LENGTH, methodNameLength));
     }
 
     public static ObfuscatorConfig defaults() {
-        return new ObfuscatorConfig(true, true, true, true, true, true, false, DEFAULT_CLASS_NAME_LENGTH,
-            false, false, false, false, false, false, List.of());
+        return new ObfuscatorConfig(true, true, true, true, true, true, true,
+            false, DEFAULT_CLASS_NAME_LENGTH, false, false,
+            false, DEFAULT_METHOD_NAME_LENGTH, false, false,
+            false, false, false, false, List.of());
     }
 }

--- a/src/main/java/st3ix/obfuscator/core/ObfuscationPipeline.java
+++ b/src/main/java/st3ix/obfuscator/core/ObfuscationPipeline.java
@@ -11,6 +11,8 @@ import st3ix.obfuscator.transform.BooleanObfuscator;
 import st3ix.obfuscator.transform.ClassMapping;
 import st3ix.obfuscator.transform.ClassRenamer;
 import st3ix.obfuscator.transform.DebugInfoStripper;
+import st3ix.obfuscator.transform.MethodMapping;
+import st3ix.obfuscator.transform.MethodRenamer;
 import st3ix.obfuscator.transform.NumberObfuscator;
 import st3ix.obfuscator.transform.StringObfuscator;
 
@@ -37,14 +39,29 @@ public final class ObfuscationPipeline {
         if (!config.classRenamingEnabled()) {
             Logger.info("Class renaming disabled by config.");
             List<ClassEntry> classesToWrite = contents.classes();
-            boolean hasTransforms = config.numberObfuscationEnabled() || config.arrayObfuscationEnabled()
-                || config.booleanObfuscationEnabled() || config.stringObfuscationEnabled()
-                || config.debugInfoStrippingEnabled();
+            boolean hasTransforms = config.methodRenamingEnabled() || config.numberObfuscationEnabled()
+                || config.arrayObfuscationEnabled() || config.booleanObfuscationEnabled()
+                || config.stringObfuscationEnabled() || config.debugInfoStrippingEnabled();
             if (hasTransforms) {
                 int stepNum = 1;
-                int totalSteps = (config.numberObfuscationEnabled() ? 1 : 0) + (config.arrayObfuscationEnabled() ? 1 : 0)
-                    + (config.booleanObfuscationEnabled() ? 1 : 0) + (config.stringObfuscationEnabled() ? 1 : 0)
-                    + (config.debugInfoStrippingEnabled() ? 1 : 0) + 1;
+                int totalSteps = (config.methodRenamingEnabled() ? 1 : 0) + (config.numberObfuscationEnabled() ? 1 : 0)
+                    + (config.arrayObfuscationEnabled() ? 1 : 0) + (config.booleanObfuscationEnabled() ? 1 : 0)
+                    + (config.stringObfuscationEnabled() ? 1 : 0) + (config.debugInfoStrippingEnabled() ? 1 : 0) + 1;
+                if (config.methodRenamingEnabled()) {
+                    Logger.step("Step %d/%d: Method renaming", stepNum++, totalSteps);
+                    MethodMapping methodMapping = new MethodMapping(config.methodNamesRandom(), config.methodNameLength(),
+                        config.methodNamesHomoglyph(), config.methodNamesInvisibleChars());
+                    methodMapping.addExcludes(config.excludeClasses());
+                    methodMapping.buildFrom(contents.classes());
+                    for (var e : methodMapping.getRenameEntries()) {
+                        Logger.info("  Method renamed: %s.%s -> %s", e.className(), e.oldName(), e.newName());
+                    }
+                    MethodRenamer methodRenamer = new MethodRenamer(methodMapping);
+                    classesToWrite = contents.classes().stream()
+                        .map(ce -> new ClassEntry(ce.path(), ce.internalName(), methodRenamer.transform(ce.bytes())))
+                        .toList();
+                    Logger.success("Method renaming applied (%d method(s))", methodMapping.getRenameEntries().size());
+                }
                 if (config.numberObfuscationEnabled()) {
                     Logger.step("Step %d/%d: Number obfuscation", stepNum++, totalSteps);
                     NumberObfuscator no = config.numberKeyRandom() ? NumberObfuscator.withRandomKey() : new NumberObfuscator();
@@ -115,14 +132,30 @@ public final class ObfuscationPipeline {
             mapping.map(name);
         }
 
+        boolean methodObfEnabled = config.methodRenamingEnabled();
         boolean numberObfEnabled = config.numberObfuscationEnabled();
         boolean arrayObfEnabled = config.arrayObfuscationEnabled();
         boolean booleanObfEnabled = config.booleanObfuscationEnabled();
         boolean stringObfEnabled = config.stringObfuscationEnabled();
         boolean debugInfoStrippingEnabled = config.debugInfoStrippingEnabled();
-        int totalSteps = 2 + (numberObfEnabled ? 1 : 0) + (arrayObfEnabled ? 1 : 0) + (booleanObfEnabled ? 1 : 0)
-            + (stringObfEnabled ? 1 : 0) + (debugInfoStrippingEnabled ? 1 : 0);
+        int totalSteps = 2 + (methodObfEnabled ? 1 : 0) + (numberObfEnabled ? 1 : 0) + (arrayObfEnabled ? 1 : 0)
+            + (booleanObfEnabled ? 1 : 0) + (stringObfEnabled ? 1 : 0) + (debugInfoStrippingEnabled ? 1 : 0);
         int stepNum = 1;
+
+        MethodMapping methodMapping = null;
+        MethodRenamer methodRenamer = null;
+        if (methodObfEnabled) {
+            Logger.step("Step %d/%d: Method renaming", stepNum++, totalSteps);
+            methodMapping = new MethodMapping(config.methodNamesRandom(), config.methodNameLength(),
+                config.methodNamesHomoglyph(), config.methodNamesInvisibleChars());
+            methodMapping.addExcludes(config.excludeClasses());
+            methodMapping.buildFrom(contents.classes());
+            for (var e : methodMapping.getRenameEntries()) {
+                Logger.info("  Method renamed: %s.%s -> %s", e.className(), e.oldName(), e.newName());
+            }
+            methodRenamer = new MethodRenamer(methodMapping);
+            Logger.success("Method renaming applied (%d method(s))", methodMapping.getRenameEntries().size());
+        }
 
         Logger.step("Step %d/%d: Class renaming", stepNum++, totalSteps);
         ClassRenamer renamer = new ClassRenamer(mapping);
@@ -147,7 +180,11 @@ public final class ObfuscationPipeline {
                 Logger.info("  Class renamed: %s -> %s", ce.internalName().replace('/', '.'), newInternal.replace('/', '.'));
                 renamedCount++;
             }
-            byte[] bytes = renamer.transform(ce.bytes());
+            byte[] bytes = ce.bytes();
+            if (methodObfEnabled) {
+                bytes = methodRenamer.transform(bytes);
+            }
+            bytes = renamer.transform(bytes);
             if (numberObfEnabled) {
                 bytes = numberObfuscator.transform(bytes);
             }

--- a/src/main/java/st3ix/obfuscator/gui/ObfuscatorGui.java
+++ b/src/main/java/st3ix/obfuscator/gui/ObfuscatorGui.java
@@ -73,6 +73,7 @@ public final class ObfuscatorGui {
             outputDir.setText(defaultOutputDir.toAbsolutePath().toString());
 
             JCheckBox classRename = new JCheckBox("Class renaming", true);
+            JCheckBox methodRename = new JCheckBox("Method renaming", true);
             JCheckBox numberObf = new JCheckBox("Number obfuscation", true);
             JCheckBox arrayObf = new JCheckBox("Array obfuscation", true);
             JCheckBox booleanObf = new JCheckBox("Boolean obfuscation", true);
@@ -87,6 +88,11 @@ public final class ObfuscatorGui {
             JCheckBox stringKeyRandom = new JCheckBox("Random string key", false);
             JSpinner classNameLength = new JSpinner(new SpinnerNumberModel(6, 1, 32, 1));
             classNameLength.setPreferredSize(new Dimension(60, 24));
+            JSpinner methodNameLength = new JSpinner(new SpinnerNumberModel(4, 1, 32, 1));
+            methodNameLength.setPreferredSize(new Dimension(60, 24));
+            JCheckBox methodNamesRandom = new JCheckBox("Random method names", false);
+            JCheckBox methodNamesHomoglyph = new JCheckBox("Homoglyph method names", false);
+            JCheckBox methodNamesInvisibleChars = new JCheckBox("Invisible chars in method names", false);
             JTextArea excludeArea = new JTextArea(4, 28);
             excludeArea.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 11));
             excludeArea.setLineWrap(false);
@@ -149,19 +155,21 @@ public final class ObfuscatorGui {
             content.add(step1, STEP_INPUT);
 
             // Step 2: Obfuscation
-            JPanel step2 = buildStep2Panel(classRename, numberObf, arrayObf, booleanObf, stringObf, debugInfoStrip, classNameLength);
+            JPanel step2 = buildStep2Panel(classRename, methodRename, numberObf, arrayObf, booleanObf, stringObf, debugInfoStrip, classNameLength, methodNameLength);
             content.add(step2, STEP_OBFUSCATION);
 
             // Step 3: Advanced
             JPanel step3 = buildStep3Panel(classNamesRandom, classNamesHomoglyph, classNamesInvisibleChars,
+                methodNamesRandom, methodNamesHomoglyph, methodNamesInvisibleChars,
                 numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, excludeArea,
-                frame, classRename, numberObf, arrayObf, booleanObf, stringObf, debugInfoStrip, classNameLength);
+                frame, classRename, methodRename, numberObf, arrayObf, booleanObf, stringObf, debugInfoStrip, classNameLength, methodNameLength);
             content.add(step3, STEP_ADVANCED);
 
             // Step 4: Run
             JPanel step4 = buildStep4Panel(inputPath, outputName, outputDir, excludeArea,
-                classRename, numberObf, arrayObf, booleanObf, stringObf, debugInfoStrip,
+                classRename, methodRename, numberObf, arrayObf, booleanObf, stringObf, debugInfoStrip,
                 classNamesRandom, classNamesHomoglyph, classNamesInvisibleChars,
+                methodNamesRandom, methodNameLength, methodNamesHomoglyph, methodNamesInvisibleChars,
                 numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, classNameLength,
                 frame, outputPane);
             content.add(step4, STEP_RUN);
@@ -335,8 +343,8 @@ public final class ObfuscatorGui {
         return step;
     }
 
-    private static JPanel buildStep2Panel(JCheckBox classRename, JCheckBox numberObf, JCheckBox arrayObf,
-            JCheckBox booleanObf, JCheckBox stringObf, JCheckBox debugInfoStrip, JSpinner classNameLength) {
+    private static JPanel buildStep2Panel(JCheckBox classRename, JCheckBox methodRename, JCheckBox numberObf, JCheckBox arrayObf,
+            JCheckBox booleanObf, JCheckBox stringObf, JCheckBox debugInfoStrip, JSpinner classNameLength, JSpinner methodNameLength) {
         JPanel step = new JPanel(new BorderLayout(8, 8));
         step.setBackground(BG_MAIN);
         step.setName(STEP_OBFUSCATION);
@@ -362,6 +370,7 @@ public final class ObfuscatorGui {
         };
         grid.setBackground(BG_PANEL);
         grid.add(classRename);
+        grid.add(methodRename);
         grid.add(numberObf);
         grid.add(arrayObf);
         grid.add(booleanObf);
@@ -372,9 +381,14 @@ public final class ObfuscatorGui {
         lengthRow.add(new JLabel("Class name length:"));
         lengthRow.add(classNameLength);
         grid.add(lengthRow);
+        JPanel methodLengthRow = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+        methodLengthRow.setBackground(BG_PANEL);
+        methodLengthRow.add(new JLabel("Method name length:"));
+        methodLengthRow.add(methodNameLength);
+        grid.add(methodLengthRow);
         inner.add(grid, BorderLayout.CENTER);
 
-        JLabel hint = new JLabel("<html>Enable or disable obfuscation types. Class name length applies when renaming.</html>");
+        JLabel hint = new JLabel("<html>Enable or disable obfuscation types. Class/method name length applies when renaming.</html>");
         hint.setFont(hint.getFont().deriveFont(10f));
         hint.setForeground(new Color(0x666666));
         hint.setBorder(new EmptyBorder(8, 0, 0, 0));
@@ -385,10 +399,11 @@ public final class ObfuscatorGui {
     }
 
     private static JPanel buildStep3Panel(JCheckBox classNamesRandom, JCheckBox classNamesHomoglyph, JCheckBox classNamesInvisibleChars,
+            JCheckBox methodNamesRandom, JCheckBox methodNamesHomoglyph, JCheckBox methodNamesInvisibleChars,
             JCheckBox numberKeyRandom, JCheckBox arrayKeyRandom, JCheckBox booleanKeyRandom, JCheckBox stringKeyRandom,
             JTextArea excludeArea, JFrame frame,
-            JCheckBox classRename, JCheckBox numberObf, JCheckBox arrayObf, JCheckBox booleanObf, JCheckBox stringObf,
-            JCheckBox debugInfoStrip, JSpinner classNameLength) {
+            JCheckBox classRename, JCheckBox methodRename, JCheckBox numberObf, JCheckBox arrayObf, JCheckBox booleanObf, JCheckBox stringObf,
+            JCheckBox debugInfoStrip, JSpinner classNameLength, JSpinner methodNameLength) {
         JPanel step = new JPanel(new BorderLayout(8, 8));
         step.setBackground(BG_MAIN);
         step.setName(STEP_ADVANCED);
@@ -407,6 +422,9 @@ public final class ObfuscatorGui {
         classOpts.add(classNamesRandom);
         classOpts.add(classNamesHomoglyph);
         classOpts.add(classNamesInvisibleChars);
+        classOpts.add(methodNamesRandom);
+        classOpts.add(methodNamesHomoglyph);
+        classOpts.add(methodNamesInvisibleChars);
         JPanel keyOpts = new JPanel(new GridLayout(0, 2, 6, 4));
         keyOpts.setBackground(BG_PANEL);
         keyOpts.add(numberKeyRandom);
@@ -440,9 +458,9 @@ public final class ObfuscatorGui {
                 ToastNotification.show(frame, "No config.yml found next to JAR. Using defaults.", ToastNotification.Type.INFO);
                 return;
             }
-            applyConfig(classRename, numberObf, arrayObf, booleanObf, stringObf, debugInfoStrip, classNamesRandom,
-                classNamesHomoglyph, classNamesInvisibleChars, numberKeyRandom, arrayKeyRandom, booleanKeyRandom,
-                stringKeyRandom, classNameLength, excludeArea, result.config());
+            applyConfig(classRename, methodRename, numberObf, arrayObf, booleanObf, stringObf, debugInfoStrip, classNamesRandom,
+                classNamesHomoglyph, classNamesInvisibleChars, methodNamesRandom, methodNameLength, methodNamesHomoglyph, methodNamesInvisibleChars,
+                numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, classNameLength, excludeArea, result.config());
             ToastNotification.show(frame, "Config loaded.", ToastNotification.Type.SUCCESS);
         });
         JButton browseConfigBtn = new JButton("Browse config...");
@@ -454,9 +472,9 @@ public final class ObfuscatorGui {
             if (fc.showOpenDialog(frame) == JFileChooser.APPROVE_OPTION) {
                 try {
                     var result = ConfigLoader.loadFrom(fc.getSelectedFile().toPath());
-                    applyConfig(classRename, numberObf, arrayObf, booleanObf, stringObf, debugInfoStrip, classNamesRandom,
-                        classNamesHomoglyph, classNamesInvisibleChars, numberKeyRandom, arrayKeyRandom, booleanKeyRandom,
-                        stringKeyRandom, classNameLength, excludeArea, result.config());
+                    applyConfig(classRename, methodRename, numberObf, arrayObf, booleanObf, stringObf, debugInfoStrip, classNamesRandom,
+                        classNamesHomoglyph, classNamesInvisibleChars, methodNamesRandom, methodNameLength, methodNamesHomoglyph, methodNamesInvisibleChars,
+                        numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, classNameLength, excludeArea, result.config());
                     ToastNotification.show(frame, "Config loaded from " + result.configPath().getFileName(), ToastNotification.Type.SUCCESS);
                 } catch (IOException ex) {
                     ToastNotification.show(frame, "Config invalid: " + ex.getMessage(), ToastNotification.Type.ERROR);
@@ -484,8 +502,9 @@ public final class ObfuscatorGui {
     }
 
     private static JPanel buildStep4Panel(JTextField inputPath, JTextField outputName, JTextField outputDir, JTextArea excludeArea,
-            JCheckBox classRename, JCheckBox numberObf, JCheckBox arrayObf, JCheckBox booleanObf, JCheckBox stringObf,
+            JCheckBox classRename, JCheckBox methodRename, JCheckBox numberObf, JCheckBox arrayObf, JCheckBox booleanObf, JCheckBox stringObf,
             JCheckBox debugInfoStrip, JCheckBox classNamesRandom, JCheckBox classNamesHomoglyph, JCheckBox classNamesInvisibleChars,
+            JCheckBox methodNamesRandom, JSpinner methodNameLength, JCheckBox methodNamesHomoglyph, JCheckBox methodNamesInvisibleChars,
             JCheckBox numberKeyRandom, JCheckBox arrayKeyRandom, JCheckBox booleanKeyRandom, JCheckBox stringKeyRandom,
             JSpinner classNameLength, JFrame frame, JTextPane outputPane) {
         JPanel step = new JPanel(new BorderLayout(8, 8));
@@ -562,6 +581,7 @@ public final class ObfuscatorGui {
 
             ObfuscatorConfig config = new ObfuscatorConfig(
                 classRename.isSelected(),
+                methodRename.isSelected(),
                 numberObf.isSelected(),
                 arrayObf.isSelected(),
                 booleanObf.isSelected(),
@@ -571,6 +591,10 @@ public final class ObfuscatorGui {
                 (Integer) classNameLength.getValue(),
                 classNamesHomoglyph.isSelected(),
                 classNamesInvisibleChars.isSelected(),
+                methodNamesRandom.isSelected(),
+                (Integer) methodNameLength.getValue(),
+                methodNamesHomoglyph.isSelected(),
+                methodNamesInvisibleChars.isSelected(),
                 numberKeyRandom.isSelected(),
                 arrayKeyRandom.isSelected(),
                 booleanKeyRandom.isSelected(),
@@ -618,12 +642,14 @@ public final class ObfuscatorGui {
         return step;
     }
 
-    private static void applyConfig(JCheckBox classRename, JCheckBox numberObf, JCheckBox arrayObf, JCheckBox booleanObf,
-            JCheckBox stringObf, JCheckBox debugInfoStrip, JCheckBox classNamesRandom, JCheckBox classNamesHomoglyph,
-            JCheckBox classNamesInvisibleChars, JCheckBox numberKeyRandom, JCheckBox arrayKeyRandom,
-            JCheckBox booleanKeyRandom, JCheckBox stringKeyRandom, JSpinner classNameLength, JTextArea excludeArea,
-            ObfuscatorConfig c) {
+    private static void applyConfig(JCheckBox classRename, JCheckBox methodRename, JCheckBox numberObf, JCheckBox arrayObf,
+            JCheckBox booleanObf, JCheckBox stringObf, JCheckBox debugInfoStrip, JCheckBox classNamesRandom,
+            JCheckBox classNamesHomoglyph, JCheckBox classNamesInvisibleChars, JCheckBox methodNamesRandom,
+            JSpinner methodNameLength, JCheckBox methodNamesHomoglyph, JCheckBox methodNamesInvisibleChars,
+            JCheckBox numberKeyRandom, JCheckBox arrayKeyRandom, JCheckBox booleanKeyRandom, JCheckBox stringKeyRandom,
+            JSpinner classNameLength, JTextArea excludeArea, ObfuscatorConfig c) {
         classRename.setSelected(c.classRenamingEnabled());
+        methodRename.setSelected(c.methodRenamingEnabled());
         numberObf.setSelected(c.numberObfuscationEnabled());
         arrayObf.setSelected(c.arrayObfuscationEnabled());
         booleanObf.setSelected(c.booleanObfuscationEnabled());
@@ -632,6 +658,10 @@ public final class ObfuscatorGui {
         classNamesRandom.setSelected(c.classNamesRandom());
         classNamesHomoglyph.setSelected(c.classNamesHomoglyph());
         classNamesInvisibleChars.setSelected(c.classNamesInvisibleChars());
+        methodNamesRandom.setSelected(c.methodNamesRandom());
+        methodNameLength.setValue(c.methodNameLength());
+        methodNamesHomoglyph.setSelected(c.methodNamesHomoglyph());
+        methodNamesInvisibleChars.setSelected(c.methodNamesInvisibleChars());
         numberKeyRandom.setSelected(c.numberKeyRandom());
         arrayKeyRandom.setSelected(c.arrayKeyRandom());
         booleanKeyRandom.setSelected(c.booleanKeyRandom());

--- a/src/main/java/st3ix/obfuscator/transform/MethodMapping.java
+++ b/src/main/java/st3ix/obfuscator/transform/MethodMapping.java
@@ -1,0 +1,215 @@
+package st3ix.obfuscator.transform;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import st3ix.obfuscator.io.JarProcessor.ClassEntry;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Maps method names for obfuscation. Handles override chains so overridden methods
+ * get the same new name. Excludes constructors, main, native methods, and enum boilerplate.
+ */
+public final class MethodMapping {
+
+    private static final String[] LIBRARY_PREFIXES = {
+        "java/", "javax/", "jdk/", "sun/", "com/sun/",
+        "org/xml/", "org/w3c/",
+        "org/bukkit/", "org/spigotmc/", "net/minecraft/",
+        "io/papermc/", "com/destroystokyo/",
+        "org/apache/", "com/google/", "org/springframework/"
+    };
+
+    private static final String MAIN_DESC = "([Ljava/lang/String;)V";
+
+    private final List<String> excludePrefixes = new ArrayList<>();
+    private final Map<String, String> oldToNew = new HashMap<>();
+    private final NameGenerator nameGen;
+    private boolean excludeAll;
+    private final Set<String> classesInJar = new HashSet<>();
+    private final Map<String, ClassInfo> classInfos = new HashMap<>();
+
+    public MethodMapping(boolean namesRandom, int nameLength, boolean useHomoglyph, boolean useInvisibleChars) {
+        this.nameGen = new NameGenerator(namesRandom, nameLength, useHomoglyph, useInvisibleChars);
+        for (String p : LIBRARY_PREFIXES) {
+            excludePrefixes.add(p);
+        }
+    }
+
+    public void addExcludes(List<String> patterns) {
+        if (patterns == null) return;
+        for (String p : patterns) {
+            if (p == null || p.isBlank()) continue;
+            String trimmed = p.trim();
+            if ("*".equals(trimmed)) {
+                excludeAll = true;
+                return;
+            }
+            String internal = trimmed.replace('.', '/');
+            if (internal.endsWith("/*")) internal = internal.substring(0, internal.length() - 1);
+            if (!internal.endsWith("/")) internal += "/";
+            excludePrefixes.add(internal);
+        }
+    }
+
+    /**
+     * Builds the method mapping from all class bytes. Must be called before getNewName.
+     */
+    public void buildFrom(List<ClassEntry> classes) {
+        for (ClassEntry ce : classes) {
+            classesInJar.add(ce.internalName());
+        }
+
+        for (ClassEntry ce : classes) {
+            if (excludeAll || isExcluded(ce.internalName())) continue;
+            ClassReader cr = new ClassReader(ce.bytes());
+            ClassInfo info = new ClassInfo(ce.internalName());
+            cr.accept(new ClassVisitor(Opcodes.ASM9) {
+                @Override
+                public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+                    info.superName = superName;
+                    info.interfaces = interfaces != null ? interfaces : new String[0];
+                    super.visit(version, access, name, signature, superName, interfaces);
+                }
+
+                @Override
+                public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+                    info.methods.add(new MethodDef(name, descriptor, access));
+                    return super.visitMethod(access, name, descriptor, signature, exceptions);
+                }
+            }, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG);
+            classInfos.put(ce.internalName(), info);
+        }
+
+        for (ClassEntry ce : classes) {
+            if (excludeAll || isExcluded(ce.internalName())) continue;
+            ClassInfo info = classInfos.get(ce.internalName());
+            if (info == null) continue;
+            for (MethodDef m : info.methods) {
+                if (!canRename(m.name, m.desc, m.access)) continue;
+                String root = findRoot(ce.internalName(), m.name, m.desc);
+                String key = root + '.' + m.name + m.desc;
+                oldToNew.computeIfAbsent(key, k -> nameGen.next());
+            }
+        }
+
+        for (ClassEntry ce : classes) {
+            if (excludeAll || isExcluded(ce.internalName())) continue;
+            ClassInfo info = classInfos.get(ce.internalName());
+            if (info == null) continue;
+            for (MethodDef m : info.methods) {
+                if (!canRename(m.name, m.desc, m.access)) continue;
+                String root = findRoot(ce.internalName(), m.name, m.desc);
+                String key = root + '.' + m.name + m.desc;
+                String newName = oldToNew.get(key);
+                if (newName != null) {
+                    oldToNew.put(ce.internalName() + '.' + m.name + m.desc, newName);
+                }
+            }
+        }
+    }
+
+    private boolean canRename(String name, String desc, int access) {
+        if ("<init>".equals(name) || "<clinit>".equals(name)) return false;
+        if ("main".equals(name) && MAIN_DESC.equals(desc)) return false;
+        if ((access & Opcodes.ACC_NATIVE) != 0) return false;
+        if ("valueOf".equals(name) && desc.startsWith("(Ljava/lang/String;)")) return false;
+        if ("values".equals(name) && desc.startsWith("()[L")) return false;  // enum values()
+        return true;
+    }
+
+    private String findRoot(String owner, String name, String desc) {
+        ClassInfo info = classInfos.get(owner);
+        if (info == null) return owner;
+
+        String superName = info.superName;
+        if (superName != null && classesInJar.contains(superName) && hasMethod(superName, name, desc)) {
+            return findRoot(superName, name, desc);
+        }
+        for (String iface : info.interfaces) {
+            if (classesInJar.contains(iface) && hasMethod(iface, name, desc)) {
+                return findRoot(iface, name, desc);
+            }
+        }
+        return owner;
+    }
+
+    private boolean hasMethod(String internalName, String name, String desc) {
+        ClassInfo info = classInfos.get(internalName);
+        if (info == null) return false;
+        for (MethodDef m : info.methods) {
+            if (m.name.equals(name) && m.desc.equals(desc)) return true;
+        }
+        return false;
+    }
+
+    public String getNewName(String owner, String name, String descriptor) {
+        if ("<init>".equals(name) || "<clinit>".equals(name)) return name;
+        String key = owner + '.' + name + descriptor;
+        return oldToNew.getOrDefault(key, name);
+    }
+
+    /**
+     * Returns all method renames for logging. Each entry: (className.methodName, newName).
+     */
+    public List<MethodRenameEntry> getRenameEntries() {
+        List<MethodRenameEntry> result = new ArrayList<>();
+        for (Map.Entry<String, String> e : oldToNew.entrySet()) {
+            String key = e.getKey();
+            String newName = e.getValue();
+            int parenIdx = key.indexOf('(');
+            if (parenIdx <= 0) continue;
+            String beforeParen = key.substring(0, parenIdx);
+            int dotIdx = beforeParen.lastIndexOf('.');
+            if (dotIdx < 0) continue;
+            String owner = beforeParen.substring(0, dotIdx);
+            String oldName = beforeParen.substring(dotIdx + 1);
+            if (!oldName.equals(newName)) {
+                result.add(new MethodRenameEntry(owner.replace('/', '.'), oldName, newName));
+            }
+        }
+        return result;
+    }
+
+    public record MethodRenameEntry(String className, String oldName, String newName) {}
+
+    private boolean isExcluded(String internalName) {
+        for (String prefix : excludePrefixes) {
+            String base = prefix.endsWith("/") ? prefix.substring(0, prefix.length() - 1) : prefix;
+            if (internalName.equals(base) || internalName.startsWith(base + "/") || internalName.startsWith(base + "$")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static final class ClassInfo {
+        final String name;
+        String superName;
+        String[] interfaces;
+        final List<MethodDef> methods = new ArrayList<>();
+
+        ClassInfo(String name) {
+            this.name = name;
+        }
+    }
+
+    private static final class MethodDef {
+        final String name;
+        final String desc;
+        final int access;
+
+        MethodDef(String name, String desc, int access) {
+            this.name = name;
+            this.desc = desc;
+            this.access = access;
+        }
+    }
+}

--- a/src/main/java/st3ix/obfuscator/transform/MethodRenamer.java
+++ b/src/main/java/st3ix/obfuscator/transform/MethodRenamer.java
@@ -1,0 +1,56 @@
+package st3ix.obfuscator.transform;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+/**
+ * Transforms class bytecode by renaming methods according to the given mapping.
+ */
+public final class MethodRenamer {
+
+    private final MethodMapping mapping;
+
+    public MethodRenamer(MethodMapping mapping) {
+        this.mapping = mapping;
+    }
+
+    /**
+     * Transforms the given class bytes. Returns the transformed bytes.
+     */
+    public byte[] transform(byte[] classBytes) {
+        ClassReader reader = new ClassReader(classBytes);
+        ClassWriter writer = new ClassWriter(reader, 0);
+        reader.accept(new MethodRenamerVisitor(writer), ClassReader.EXPAND_FRAMES);
+        return writer.toByteArray();
+    }
+
+    private final class MethodRenamerVisitor extends ClassVisitor {
+        private String ownerInternalName;
+
+        MethodRenamerVisitor(ClassVisitor cv) {
+            super(Opcodes.ASM9, cv);
+        }
+
+        @Override
+        public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+            ownerInternalName = name;
+            super.visit(version, access, name, signature, superName, interfaces);
+        }
+
+        @Override
+        public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+            String newName = mapping.getNewName(ownerInternalName, name, descriptor);
+            MethodVisitor mv = super.visitMethod(access, newName, descriptor, signature, exceptions);
+            return new MethodVisitor(Opcodes.ASM9, mv) {
+                @Override
+                public void visitMethodInsn(int opcode, String owner, String methodName, String methodDesc, boolean isInterface) {
+                    String mappedName = mapping.getNewName(owner, methodName, methodDesc);
+                    super.visitMethodInsn(opcode, owner, mappedName, methodDesc, isInterface);
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Add Method Renaming as a new obfuscation option so method names can be obfuscated similarly to class names.

## Changes
- **MethodMapping**: Builds method name mapping and handles override chains
- **MethodRenamer**: ASM transformation for method definitions and calls
- **Config**: methodRenamingEnabled, methodNameLength, methodNamesRandom, methodNamesHomoglyph, methodNamesInvisibleChars
- **GUI**: Checkbox and options in Obfuscation tab, method options in Advanced tab
- **Logging**: Show renamed methods as `Method renamed: className.methodName -> newName`

## Tested
- [ ] Build successful
- [ ] Obfuscation with method renaming enabled
- [ ] Log shows renamed methods



Closes #26 