### PR TITLE
feat: add field renaming and obfuscation verification demo

### DIFF
--- a/Example/Java Project/src/main/java/example/Main.java
+++ b/Example/Java Project/src/main/java/example/Main.java
@@ -10,6 +10,7 @@ public final class Main {
         DemoService service = new DemoService();
         service.run();
         new DebugStrippingDemo().demonstrateLocalVariables();
+        new ObfuscationVerifyDemo().verify();
         CrossRefTest crossRef = new CrossRefTest();
         crossRef.run();
     }

--- a/Example/Java Project/src/main/java/example/ObfuscationVerifyDemo.java
+++ b/Example/Java Project/src/main/java/example/ObfuscationVerifyDemo.java
@@ -1,0 +1,38 @@
+package example;
+
+/**
+ * Verification demo for obfuscation. Use this to confirm that obfuscation works:
+ *
+ * 1. Build & obfuscate the Example project
+ * 2. Decompile the output JAR (e.g. with CFR, Fernflower, JD-GUI)
+ * 3. Open this class and check:
+ *
+ * NUMBER OBFUSCATION:     port=25565, seed=12345, threshold=1000
+ *    → Should become:      int n = 0x???? ^ 0x????; etc.
+ *
+ * DEBUG STRIPPING:        Local vars port, seed, threshold
+ *    → Should become:     n, n2, n3 (or var0, var1, var2)
+ *
+ * FIELD RENAMING:         apiKey field
+ *    → Should become:     Short name like a, b, f
+ *
+ * Run with: java -jar .../example-java-project-obfuscated.jar ObfuscationVerifyDemo
+ */
+public final class ObfuscationVerifyDemo {
+
+    private static final String apiKey = "verify-field-renaming";
+
+    public static void main(String[] args) {
+        ObfuscationVerifyDemo demo = new ObfuscationVerifyDemo();
+        demo.verify();
+    }
+
+    public void verify() {
+        int port = 25565;
+        int seed = 12345;
+        int threshold = 1000;
+
+        System.out.println("ObfuscationVerifyDemo: port=" + port + ", seed=" + seed + ", threshold=" + threshold);
+        System.out.println("Field (apiKey): " + apiKey);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ Bei jedem Release gibt es ein ZIP-Archiv mit allem Nötigen: JAR, Batch-Datei zu
 
 - **Class renaming** – Short or random names; configurable length
 - **Method renaming** – Obfuscate method names; handles override chains
-- **Local variable & field renaming** *(planned)* – Obfuscate field and local variable names
+- **Field renaming** – Obfuscate field names; excludes serialVersionUID and enum constants
 - **Homoglyph & invisible chars** – Unicode lookalikes (a→а) and zero-width chars; copy-paste fails
 - **Number obfuscation** – Hides `int`, `long`, `float`, `double` with XOR
 - **Array obfuscation** – Hides array dimensions
 - **Boolean obfuscation** – Hides `true`/`false` literals
 - **String obfuscation** – Encrypts string literals (XOR), decrypts at runtime
 - **Debug info stripping** – Removes source names, line numbers, local variable names
-- **Local variable & field renaming** *(planned)* – Obfuscate field and local variable names
+- **Local variable renaming** *(planned)* – Obfuscate local variable names when debug kept
 - **Random options** – Optional random keys and class/method names per build
 - **Exclude patterns** – Skip JDK, Bukkit, Minecraft, and custom packages
 - **YAML config** – `config.yml` next to the JAR
@@ -170,6 +170,8 @@ public final class ь {
 | Transform        | Effect                                                                 |
 |------------------|-----------------------------------------------------------------------|
 | Class renaming   | `Main` → `b`, `DemoService` → `ь` (short names; homoglyph: `а`, `ь`)  |
+| Method renaming  | `run()` → `a()` (excludes main, constructors, native)                 |
+| Field renaming   | `SECRET_KEY` → `f`, `counter` → `g`                                  |
 | Homoglyph        | Latin `a` becomes Cyrillic `а` (U+0430) – copy-paste fails           |
 | Invisible chars  | Zero-width chars in names – appear normal but differ                 |
 | Number obfuscation | `25565` → `(x ^ key) ^ key`; floats/doubles via bit XOR             |

--- a/config.yml.example
+++ b/config.yml.example
@@ -6,6 +6,9 @@ classRenamingEnabled: true
 # Enable or disable method renaming (excludes constructors, main, native, enum methods)
 methodRenamingEnabled: true
 
+# Enable or disable field renaming (excludes serialVersionUID, enum constants)
+fieldRenamingEnabled: true
+
 # Obfuscate numeric constants (int, long, float, double) using XOR
 numberObfuscationEnabled: true
 
@@ -32,6 +35,12 @@ methodNamesRandom: false   # true = random method names per build, false = seque
 methodNameLength: 4        # minimum length of method names (1-32)
 methodNamesHomoglyph: false   # use lookalike chars for method names
 methodNamesInvisibleChars: false  # inject zero-width chars in method names
+
+# Field name generation
+fieldNamesRandom: false    # true = random field names per build
+fieldNameLength: 4         # minimum length of field names (1-32)
+fieldNamesHomoglyph: false # use lookalike chars for field names
+fieldNamesInvisibleChars: false  # inject zero-width chars in field names
 
 # Obfuscation keys (XOR)
 numberKeyRandom: false   # true = random key per build, false = fixed key

--- a/src/main/java/st3ix/obfuscator/config/ConfigLoader.java
+++ b/src/main/java/st3ix/obfuscator/config/ConfigLoader.java
@@ -38,6 +38,7 @@ public final class ConfigLoader {
 
             boolean classRenamingEnabled = getBoolean(raw, "classRenamingEnabled", true);
             boolean methodRenamingEnabled = getBoolean(raw, "methodRenamingEnabled", true);
+            boolean fieldRenamingEnabled = getBoolean(raw, "fieldRenamingEnabled", true);
             boolean numberObfuscationEnabled = getBoolean(raw, "numberObfuscationEnabled", true);
             boolean arrayObfuscationEnabled = getBoolean(raw, "arrayObfuscationEnabled", true);
             boolean booleanObfuscationEnabled = getBoolean(raw, "booleanObfuscationEnabled", true);
@@ -51,6 +52,10 @@ public final class ConfigLoader {
             int methodNameLength = getInt(raw, "methodNameLength", 4);
             boolean methodNamesHomoglyph = getBoolean(raw, "methodNamesHomoglyph", false);
             boolean methodNamesInvisibleChars = getBoolean(raw, "methodNamesInvisibleChars", false);
+            boolean fieldNamesRandom = getBoolean(raw, "fieldNamesRandom", false);
+            int fieldNameLength = getInt(raw, "fieldNameLength", 4);
+            boolean fieldNamesHomoglyph = getBoolean(raw, "fieldNamesHomoglyph", false);
+            boolean fieldNamesInvisibleChars = getBoolean(raw, "fieldNamesInvisibleChars", false);
             boolean numberKeyRandom = getBoolean(raw, "numberKeyRandom", false);
             boolean arrayKeyRandom = getBoolean(raw, "arrayKeyRandom", false);
             boolean booleanKeyRandom = getBoolean(raw, "booleanKeyRandom", false);
@@ -58,10 +63,11 @@ public final class ConfigLoader {
             List<String> excludeClasses = getStringList(raw, "excludeClasses");
 
             return new LoadResult(new ObfuscatorConfig(
-                classRenamingEnabled, methodRenamingEnabled, numberObfuscationEnabled, arrayObfuscationEnabled,
+                classRenamingEnabled, methodRenamingEnabled, fieldRenamingEnabled, numberObfuscationEnabled, arrayObfuscationEnabled,
                 booleanObfuscationEnabled, stringObfuscationEnabled, debugInfoStrippingEnabled,
                 classNamesRandom, classNameLength, classNamesHomoglyph, classNamesInvisibleChars,
                 methodNamesRandom, methodNameLength, methodNamesHomoglyph, methodNamesInvisibleChars,
+                fieldNamesRandom, fieldNameLength, fieldNamesHomoglyph, fieldNamesInvisibleChars,
                 numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, excludeClasses
             ), configPath);
         } catch (Exception e) {
@@ -86,6 +92,7 @@ public final class ConfigLoader {
         try {
             boolean classRenamingEnabled = getBoolean(raw, "classRenamingEnabled", true);
             boolean methodRenamingEnabled = getBoolean(raw, "methodRenamingEnabled", true);
+            boolean fieldRenamingEnabled = getBoolean(raw, "fieldRenamingEnabled", true);
             boolean numberObfuscationEnabled = getBoolean(raw, "numberObfuscationEnabled", true);
             boolean arrayObfuscationEnabled = getBoolean(raw, "arrayObfuscationEnabled", true);
             boolean booleanObfuscationEnabled = getBoolean(raw, "booleanObfuscationEnabled", true);
@@ -99,16 +106,21 @@ public final class ConfigLoader {
             int methodNameLength = getInt(raw, "methodNameLength", 4);
             boolean methodNamesHomoglyph = getBoolean(raw, "methodNamesHomoglyph", false);
             boolean methodNamesInvisibleChars = getBoolean(raw, "methodNamesInvisibleChars", false);
+            boolean fieldNamesRandom = getBoolean(raw, "fieldNamesRandom", false);
+            int fieldNameLength = getInt(raw, "fieldNameLength", 4);
+            boolean fieldNamesHomoglyph = getBoolean(raw, "fieldNamesHomoglyph", false);
+            boolean fieldNamesInvisibleChars = getBoolean(raw, "fieldNamesInvisibleChars", false);
             boolean numberKeyRandom = getBoolean(raw, "numberKeyRandom", false);
             boolean arrayKeyRandom = getBoolean(raw, "arrayKeyRandom", false);
             boolean booleanKeyRandom = getBoolean(raw, "booleanKeyRandom", false);
             boolean stringKeyRandom = getBoolean(raw, "stringKeyRandom", false);
             List<String> excludeClasses = getStringList(raw, "excludeClasses");
             return new LoadResult(new ObfuscatorConfig(
-                classRenamingEnabled, methodRenamingEnabled, numberObfuscationEnabled, arrayObfuscationEnabled,
+                classRenamingEnabled, methodRenamingEnabled, fieldRenamingEnabled, numberObfuscationEnabled, arrayObfuscationEnabled,
                 booleanObfuscationEnabled, stringObfuscationEnabled, debugInfoStrippingEnabled,
                 classNamesRandom, classNameLength, classNamesHomoglyph, classNamesInvisibleChars,
                 methodNamesRandom, methodNameLength, methodNamesHomoglyph, methodNamesInvisibleChars,
+                fieldNamesRandom, fieldNameLength, fieldNamesHomoglyph, fieldNamesInvisibleChars,
                 numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, excludeClasses
             ), configPath);
         } catch (Exception e) {

--- a/src/main/java/st3ix/obfuscator/config/ObfuscatorConfig.java
+++ b/src/main/java/st3ix/obfuscator/config/ObfuscatorConfig.java
@@ -9,6 +9,7 @@ import java.util.List;
 public record ObfuscatorConfig(
     boolean classRenamingEnabled,
     boolean methodRenamingEnabled,
+    boolean fieldRenamingEnabled,
     boolean numberObfuscationEnabled,
     boolean arrayObfuscationEnabled,
     boolean booleanObfuscationEnabled,
@@ -22,6 +23,10 @@ public record ObfuscatorConfig(
     int methodNameLength,
     boolean methodNamesHomoglyph,
     boolean methodNamesInvisibleChars,
+    boolean fieldNamesRandom,
+    int fieldNameLength,
+    boolean fieldNamesHomoglyph,
+    boolean fieldNamesInvisibleChars,
     boolean numberKeyRandom,
     boolean arrayKeyRandom,
     boolean booleanKeyRandom,
@@ -30,20 +35,24 @@ public record ObfuscatorConfig(
 ) {
     private static final int DEFAULT_CLASS_NAME_LENGTH = 6;
     private static final int DEFAULT_METHOD_NAME_LENGTH = 4;
+    private static final int DEFAULT_FIELD_NAME_LENGTH = 4;
     private static final int MIN_NAME_LENGTH = 1;
     private static final int MAX_CLASS_NAME_LENGTH = 32;
     private static final int MAX_METHOD_NAME_LENGTH = 32;
+    private static final int MAX_FIELD_NAME_LENGTH = 32;
 
     public ObfuscatorConfig {
         excludeClasses = excludeClasses != null ? List.copyOf(excludeClasses) : Collections.emptyList();
         classNameLength = Math.max(MIN_NAME_LENGTH, Math.min(MAX_CLASS_NAME_LENGTH, classNameLength));
         methodNameLength = Math.max(MIN_NAME_LENGTH, Math.min(MAX_METHOD_NAME_LENGTH, methodNameLength));
+        fieldNameLength = Math.max(MIN_NAME_LENGTH, Math.min(MAX_FIELD_NAME_LENGTH, fieldNameLength));
     }
 
     public static ObfuscatorConfig defaults() {
-        return new ObfuscatorConfig(true, true, true, true, true, true, true,
+        return new ObfuscatorConfig(true, true, true, true, true, true, true, true,
             false, DEFAULT_CLASS_NAME_LENGTH, false, false,
             false, DEFAULT_METHOD_NAME_LENGTH, false, false,
+            false, DEFAULT_FIELD_NAME_LENGTH, false, false,
             false, false, false, false, List.of());
     }
 }

--- a/src/main/java/st3ix/obfuscator/core/ObfuscationPipeline.java
+++ b/src/main/java/st3ix/obfuscator/core/ObfuscationPipeline.java
@@ -11,6 +11,8 @@ import st3ix.obfuscator.transform.BooleanObfuscator;
 import st3ix.obfuscator.transform.ClassMapping;
 import st3ix.obfuscator.transform.ClassRenamer;
 import st3ix.obfuscator.transform.DebugInfoStripper;
+import st3ix.obfuscator.transform.FieldMapping;
+import st3ix.obfuscator.transform.FieldRenamer;
 import st3ix.obfuscator.transform.MethodMapping;
 import st3ix.obfuscator.transform.MethodRenamer;
 import st3ix.obfuscator.transform.NumberObfuscator;
@@ -39,14 +41,15 @@ public final class ObfuscationPipeline {
         if (!config.classRenamingEnabled()) {
             Logger.info("Class renaming disabled by config.");
             List<ClassEntry> classesToWrite = contents.classes();
-            boolean hasTransforms = config.methodRenamingEnabled() || config.numberObfuscationEnabled()
+            boolean hasTransforms = config.methodRenamingEnabled() || config.fieldRenamingEnabled() || config.numberObfuscationEnabled()
                 || config.arrayObfuscationEnabled() || config.booleanObfuscationEnabled()
                 || config.stringObfuscationEnabled() || config.debugInfoStrippingEnabled();
             if (hasTransforms) {
                 int stepNum = 1;
-                int totalSteps = (config.methodRenamingEnabled() ? 1 : 0) + (config.numberObfuscationEnabled() ? 1 : 0)
-                    + (config.arrayObfuscationEnabled() ? 1 : 0) + (config.booleanObfuscationEnabled() ? 1 : 0)
-                    + (config.stringObfuscationEnabled() ? 1 : 0) + (config.debugInfoStrippingEnabled() ? 1 : 0) + 1;
+                int totalSteps = (config.methodRenamingEnabled() ? 1 : 0) + (config.fieldRenamingEnabled() ? 1 : 0)
+                    + (config.numberObfuscationEnabled() ? 1 : 0) + (config.arrayObfuscationEnabled() ? 1 : 0)
+                    + (config.booleanObfuscationEnabled() ? 1 : 0) + (config.stringObfuscationEnabled() ? 1 : 0)
+                    + (config.debugInfoStrippingEnabled() ? 1 : 0) + 1;
                 if (config.methodRenamingEnabled()) {
                     Logger.step("Step %d/%d: Method renaming", stepNum++, totalSteps);
                     MethodMapping methodMapping = new MethodMapping(config.methodNamesRandom(), config.methodNameLength(),
@@ -62,10 +65,25 @@ public final class ObfuscationPipeline {
                         .toList();
                     Logger.success("Method renaming applied (%d method(s))", methodMapping.getRenameEntries().size());
                 }
+                if (config.fieldRenamingEnabled()) {
+                    Logger.step("Step %d/%d: Field renaming", stepNum++, totalSteps);
+                    FieldMapping fieldMapping = new FieldMapping(config.fieldNamesRandom(), config.fieldNameLength(),
+                        config.fieldNamesHomoglyph(), config.fieldNamesInvisibleChars());
+                    fieldMapping.addExcludes(config.excludeClasses());
+                    fieldMapping.buildFrom(classesToWrite);
+                    for (var e : fieldMapping.getRenameEntries()) {
+                        Logger.info("  Field renamed: %s.%s -> %s", e.className(), e.oldName(), e.newName());
+                    }
+                    FieldRenamer fieldRenamer = new FieldRenamer(fieldMapping);
+                    classesToWrite = classesToWrite.stream()
+                        .map(ce -> new ClassEntry(ce.path(), ce.internalName(), fieldRenamer.transform(ce.bytes())))
+                        .toList();
+                    Logger.success("Field renaming applied (%d field(s))", fieldMapping.getRenameEntries().size());
+                }
                 if (config.numberObfuscationEnabled()) {
                     Logger.step("Step %d/%d: Number obfuscation", stepNum++, totalSteps);
                     NumberObfuscator no = config.numberKeyRandom() ? NumberObfuscator.withRandomKey() : new NumberObfuscator();
-                    classesToWrite = contents.classes().stream()
+                    classesToWrite = classesToWrite.stream()
                         .map(ce -> new ClassEntry(ce.path(), ce.internalName(), no.transform(ce.bytes())))
                         .toList();
                     Logger.success("Number obfuscation applied");
@@ -133,17 +151,20 @@ public final class ObfuscationPipeline {
         }
 
         boolean methodObfEnabled = config.methodRenamingEnabled();
+        boolean fieldObfEnabled = config.fieldRenamingEnabled();
         boolean numberObfEnabled = config.numberObfuscationEnabled();
         boolean arrayObfEnabled = config.arrayObfuscationEnabled();
         boolean booleanObfEnabled = config.booleanObfuscationEnabled();
         boolean stringObfEnabled = config.stringObfuscationEnabled();
         boolean debugInfoStrippingEnabled = config.debugInfoStrippingEnabled();
-        int totalSteps = 2 + (methodObfEnabled ? 1 : 0) + (numberObfEnabled ? 1 : 0) + (arrayObfEnabled ? 1 : 0)
+        int totalSteps = 2 + (methodObfEnabled ? 1 : 0) + (fieldObfEnabled ? 1 : 0) + (numberObfEnabled ? 1 : 0) + (arrayObfEnabled ? 1 : 0)
             + (booleanObfEnabled ? 1 : 0) + (stringObfEnabled ? 1 : 0) + (debugInfoStrippingEnabled ? 1 : 0);
         int stepNum = 1;
 
         MethodMapping methodMapping = null;
         MethodRenamer methodRenamer = null;
+        FieldMapping fieldMapping = null;
+        FieldRenamer fieldRenamer = null;
         if (methodObfEnabled) {
             Logger.step("Step %d/%d: Method renaming", stepNum++, totalSteps);
             methodMapping = new MethodMapping(config.methodNamesRandom(), config.methodNameLength(),
@@ -155,6 +176,19 @@ public final class ObfuscationPipeline {
             }
             methodRenamer = new MethodRenamer(methodMapping);
             Logger.success("Method renaming applied (%d method(s))", methodMapping.getRenameEntries().size());
+        }
+
+        if (fieldObfEnabled) {
+            Logger.step("Step %d/%d: Field renaming", stepNum++, totalSteps);
+            fieldMapping = new FieldMapping(config.fieldNamesRandom(), config.fieldNameLength(),
+                config.fieldNamesHomoglyph(), config.fieldNamesInvisibleChars());
+            fieldMapping.addExcludes(config.excludeClasses());
+            fieldMapping.buildFrom(contents.classes());
+            for (var e : fieldMapping.getRenameEntries()) {
+                Logger.info("  Field renamed: %s.%s -> %s", e.className(), e.oldName(), e.newName());
+            }
+            fieldRenamer = new FieldRenamer(fieldMapping);
+            Logger.success("Field renaming applied (%d field(s))", fieldMapping.getRenameEntries().size());
         }
 
         Logger.step("Step %d/%d: Class renaming", stepNum++, totalSteps);
@@ -183,6 +217,9 @@ public final class ObfuscationPipeline {
             byte[] bytes = ce.bytes();
             if (methodObfEnabled) {
                 bytes = methodRenamer.transform(bytes);
+            }
+            if (fieldObfEnabled) {
+                bytes = fieldRenamer.transform(bytes);
             }
             bytes = renamer.transform(bytes);
             if (numberObfEnabled) {

--- a/src/main/java/st3ix/obfuscator/gui/ObfuscatorGui.java
+++ b/src/main/java/st3ix/obfuscator/gui/ObfuscatorGui.java
@@ -74,6 +74,7 @@ public final class ObfuscatorGui {
 
             JCheckBox classRename = new JCheckBox("Class renaming", true);
             JCheckBox methodRename = new JCheckBox("Method renaming", true);
+            JCheckBox fieldRename = new JCheckBox("Field renaming", true);
             JCheckBox numberObf = new JCheckBox("Number obfuscation", true);
             JCheckBox arrayObf = new JCheckBox("Array obfuscation", true);
             JCheckBox booleanObf = new JCheckBox("Boolean obfuscation", true);
@@ -93,6 +94,11 @@ public final class ObfuscatorGui {
             JCheckBox methodNamesRandom = new JCheckBox("Random method names", false);
             JCheckBox methodNamesHomoglyph = new JCheckBox("Homoglyph method names", false);
             JCheckBox methodNamesInvisibleChars = new JCheckBox("Invisible chars in method names", false);
+            JCheckBox fieldNamesRandom = new JCheckBox("Random field names", false);
+            JCheckBox fieldNamesHomoglyph = new JCheckBox("Homoglyph field names", false);
+            JCheckBox fieldNamesInvisibleChars = new JCheckBox("Invisible chars in field names", false);
+            JSpinner fieldNameLength = new JSpinner(new SpinnerNumberModel(4, 1, 32, 1));
+            fieldNameLength.setPreferredSize(new Dimension(60, 24));
             JTextArea excludeArea = new JTextArea(4, 28);
             excludeArea.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 11));
             excludeArea.setLineWrap(false);
@@ -155,21 +161,23 @@ public final class ObfuscatorGui {
             content.add(step1, STEP_INPUT);
 
             // Step 2: Obfuscation
-            JPanel step2 = buildStep2Panel(classRename, methodRename, numberObf, arrayObf, booleanObf, stringObf, debugInfoStrip, classNameLength, methodNameLength);
+            JPanel step2 = buildStep2Panel(classRename, methodRename, fieldRename, numberObf, arrayObf, booleanObf, stringObf, debugInfoStrip, classNameLength, methodNameLength, fieldNameLength);
             content.add(step2, STEP_OBFUSCATION);
 
             // Step 3: Advanced
             JPanel step3 = buildStep3Panel(classNamesRandom, classNamesHomoglyph, classNamesInvisibleChars,
                 methodNamesRandom, methodNamesHomoglyph, methodNamesInvisibleChars,
+                fieldNamesRandom, fieldNamesHomoglyph, fieldNamesInvisibleChars,
                 numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, excludeArea,
-                frame, classRename, methodRename, numberObf, arrayObf, booleanObf, stringObf, debugInfoStrip, classNameLength, methodNameLength);
+                frame, classRename, methodRename, fieldRename, numberObf, arrayObf, booleanObf, stringObf, debugInfoStrip, classNameLength, methodNameLength, fieldNameLength);
             content.add(step3, STEP_ADVANCED);
 
             // Step 4: Run
             JPanel step4 = buildStep4Panel(inputPath, outputName, outputDir, excludeArea,
-                classRename, methodRename, numberObf, arrayObf, booleanObf, stringObf, debugInfoStrip,
+                classRename, methodRename, fieldRename, numberObf, arrayObf, booleanObf, stringObf, debugInfoStrip,
                 classNamesRandom, classNamesHomoglyph, classNamesInvisibleChars,
                 methodNamesRandom, methodNameLength, methodNamesHomoglyph, methodNamesInvisibleChars,
+                fieldNamesRandom, fieldNameLength, fieldNamesHomoglyph, fieldNamesInvisibleChars,
                 numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, classNameLength,
                 frame, outputPane);
             content.add(step4, STEP_RUN);
@@ -343,8 +351,8 @@ public final class ObfuscatorGui {
         return step;
     }
 
-    private static JPanel buildStep2Panel(JCheckBox classRename, JCheckBox methodRename, JCheckBox numberObf, JCheckBox arrayObf,
-            JCheckBox booleanObf, JCheckBox stringObf, JCheckBox debugInfoStrip, JSpinner classNameLength, JSpinner methodNameLength) {
+    private static JPanel buildStep2Panel(JCheckBox classRename, JCheckBox methodRename, JCheckBox fieldRename, JCheckBox numberObf, JCheckBox arrayObf,
+            JCheckBox booleanObf, JCheckBox stringObf, JCheckBox debugInfoStrip, JSpinner classNameLength, JSpinner methodNameLength, JSpinner fieldNameLength) {
         JPanel step = new JPanel(new BorderLayout(8, 8));
         step.setBackground(BG_MAIN);
         step.setName(STEP_OBFUSCATION);
@@ -371,6 +379,7 @@ public final class ObfuscatorGui {
         grid.setBackground(BG_PANEL);
         grid.add(classRename);
         grid.add(methodRename);
+        grid.add(fieldRename);
         grid.add(numberObf);
         grid.add(arrayObf);
         grid.add(booleanObf);
@@ -386,6 +395,11 @@ public final class ObfuscatorGui {
         methodLengthRow.add(new JLabel("Method name length:"));
         methodLengthRow.add(methodNameLength);
         grid.add(methodLengthRow);
+        JPanel fieldLengthRow = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+        fieldLengthRow.setBackground(BG_PANEL);
+        fieldLengthRow.add(new JLabel("Field name length:"));
+        fieldLengthRow.add(fieldNameLength);
+        grid.add(fieldLengthRow);
         inner.add(grid, BorderLayout.CENTER);
 
         JLabel hint = new JLabel("<html>Enable or disable obfuscation types. Class/method name length applies when renaming.</html>");
@@ -400,10 +414,11 @@ public final class ObfuscatorGui {
 
     private static JPanel buildStep3Panel(JCheckBox classNamesRandom, JCheckBox classNamesHomoglyph, JCheckBox classNamesInvisibleChars,
             JCheckBox methodNamesRandom, JCheckBox methodNamesHomoglyph, JCheckBox methodNamesInvisibleChars,
+            JCheckBox fieldNamesRandom, JCheckBox fieldNamesHomoglyph, JCheckBox fieldNamesInvisibleChars,
             JCheckBox numberKeyRandom, JCheckBox arrayKeyRandom, JCheckBox booleanKeyRandom, JCheckBox stringKeyRandom,
             JTextArea excludeArea, JFrame frame,
-            JCheckBox classRename, JCheckBox methodRename, JCheckBox numberObf, JCheckBox arrayObf, JCheckBox booleanObf, JCheckBox stringObf,
-            JCheckBox debugInfoStrip, JSpinner classNameLength, JSpinner methodNameLength) {
+            JCheckBox classRename, JCheckBox methodRename, JCheckBox fieldRename, JCheckBox numberObf, JCheckBox arrayObf, JCheckBox booleanObf, JCheckBox stringObf,
+            JCheckBox debugInfoStrip, JSpinner classNameLength, JSpinner methodNameLength, JSpinner fieldNameLength) {
         JPanel step = new JPanel(new BorderLayout(8, 8));
         step.setBackground(BG_MAIN);
         step.setName(STEP_ADVANCED);
@@ -425,6 +440,9 @@ public final class ObfuscatorGui {
         classOpts.add(methodNamesRandom);
         classOpts.add(methodNamesHomoglyph);
         classOpts.add(methodNamesInvisibleChars);
+        classOpts.add(fieldNamesRandom);
+        classOpts.add(fieldNamesHomoglyph);
+        classOpts.add(fieldNamesInvisibleChars);
         JPanel keyOpts = new JPanel(new GridLayout(0, 2, 6, 4));
         keyOpts.setBackground(BG_PANEL);
         keyOpts.add(numberKeyRandom);
@@ -458,8 +476,9 @@ public final class ObfuscatorGui {
                 ToastNotification.show(frame, "No config.yml found next to JAR. Using defaults.", ToastNotification.Type.INFO);
                 return;
             }
-            applyConfig(classRename, methodRename, numberObf, arrayObf, booleanObf, stringObf, debugInfoStrip, classNamesRandom,
+            applyConfig(classRename, methodRename, fieldRename, numberObf, arrayObf, booleanObf, stringObf, debugInfoStrip, classNamesRandom,
                 classNamesHomoglyph, classNamesInvisibleChars, methodNamesRandom, methodNameLength, methodNamesHomoglyph, methodNamesInvisibleChars,
+                fieldNamesRandom, fieldNameLength, fieldNamesHomoglyph, fieldNamesInvisibleChars,
                 numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, classNameLength, excludeArea, result.config());
             ToastNotification.show(frame, "Config loaded.", ToastNotification.Type.SUCCESS);
         });
@@ -472,8 +491,9 @@ public final class ObfuscatorGui {
             if (fc.showOpenDialog(frame) == JFileChooser.APPROVE_OPTION) {
                 try {
                     var result = ConfigLoader.loadFrom(fc.getSelectedFile().toPath());
-                    applyConfig(classRename, methodRename, numberObf, arrayObf, booleanObf, stringObf, debugInfoStrip, classNamesRandom,
+                    applyConfig(classRename, methodRename, fieldRename, numberObf, arrayObf, booleanObf, stringObf, debugInfoStrip, classNamesRandom,
                         classNamesHomoglyph, classNamesInvisibleChars, methodNamesRandom, methodNameLength, methodNamesHomoglyph, methodNamesInvisibleChars,
+                        fieldNamesRandom, fieldNameLength, fieldNamesHomoglyph, fieldNamesInvisibleChars,
                         numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, classNameLength, excludeArea, result.config());
                     ToastNotification.show(frame, "Config loaded from " + result.configPath().getFileName(), ToastNotification.Type.SUCCESS);
                 } catch (IOException ex) {
@@ -502,9 +522,10 @@ public final class ObfuscatorGui {
     }
 
     private static JPanel buildStep4Panel(JTextField inputPath, JTextField outputName, JTextField outputDir, JTextArea excludeArea,
-            JCheckBox classRename, JCheckBox methodRename, JCheckBox numberObf, JCheckBox arrayObf, JCheckBox booleanObf, JCheckBox stringObf,
+            JCheckBox classRename, JCheckBox methodRename, JCheckBox fieldRename, JCheckBox numberObf, JCheckBox arrayObf, JCheckBox booleanObf, JCheckBox stringObf,
             JCheckBox debugInfoStrip, JCheckBox classNamesRandom, JCheckBox classNamesHomoglyph, JCheckBox classNamesInvisibleChars,
             JCheckBox methodNamesRandom, JSpinner methodNameLength, JCheckBox methodNamesHomoglyph, JCheckBox methodNamesInvisibleChars,
+            JCheckBox fieldNamesRandom, JSpinner fieldNameLength, JCheckBox fieldNamesHomoglyph, JCheckBox fieldNamesInvisibleChars,
             JCheckBox numberKeyRandom, JCheckBox arrayKeyRandom, JCheckBox booleanKeyRandom, JCheckBox stringKeyRandom,
             JSpinner classNameLength, JFrame frame, JTextPane outputPane) {
         JPanel step = new JPanel(new BorderLayout(8, 8));
@@ -582,6 +603,7 @@ public final class ObfuscatorGui {
             ObfuscatorConfig config = new ObfuscatorConfig(
                 classRename.isSelected(),
                 methodRename.isSelected(),
+                fieldRename.isSelected(),
                 numberObf.isSelected(),
                 arrayObf.isSelected(),
                 booleanObf.isSelected(),
@@ -595,6 +617,10 @@ public final class ObfuscatorGui {
                 (Integer) methodNameLength.getValue(),
                 methodNamesHomoglyph.isSelected(),
                 methodNamesInvisibleChars.isSelected(),
+                fieldNamesRandom.isSelected(),
+                (Integer) fieldNameLength.getValue(),
+                fieldNamesHomoglyph.isSelected(),
+                fieldNamesInvisibleChars.isSelected(),
                 numberKeyRandom.isSelected(),
                 arrayKeyRandom.isSelected(),
                 booleanKeyRandom.isSelected(),
@@ -642,14 +668,16 @@ public final class ObfuscatorGui {
         return step;
     }
 
-    private static void applyConfig(JCheckBox classRename, JCheckBox methodRename, JCheckBox numberObf, JCheckBox arrayObf,
+    private static void applyConfig(JCheckBox classRename, JCheckBox methodRename, JCheckBox fieldRename, JCheckBox numberObf, JCheckBox arrayObf,
             JCheckBox booleanObf, JCheckBox stringObf, JCheckBox debugInfoStrip, JCheckBox classNamesRandom,
             JCheckBox classNamesHomoglyph, JCheckBox classNamesInvisibleChars, JCheckBox methodNamesRandom,
             JSpinner methodNameLength, JCheckBox methodNamesHomoglyph, JCheckBox methodNamesInvisibleChars,
+            JCheckBox fieldNamesRandom, JSpinner fieldNameLength, JCheckBox fieldNamesHomoglyph, JCheckBox fieldNamesInvisibleChars,
             JCheckBox numberKeyRandom, JCheckBox arrayKeyRandom, JCheckBox booleanKeyRandom, JCheckBox stringKeyRandom,
             JSpinner classNameLength, JTextArea excludeArea, ObfuscatorConfig c) {
         classRename.setSelected(c.classRenamingEnabled());
         methodRename.setSelected(c.methodRenamingEnabled());
+        fieldRename.setSelected(c.fieldRenamingEnabled());
         numberObf.setSelected(c.numberObfuscationEnabled());
         arrayObf.setSelected(c.arrayObfuscationEnabled());
         booleanObf.setSelected(c.booleanObfuscationEnabled());

--- a/src/main/java/st3ix/obfuscator/transform/FieldMapping.java
+++ b/src/main/java/st3ix/obfuscator/transform/FieldMapping.java
@@ -1,0 +1,159 @@
+package st3ix.obfuscator.transform;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.Opcodes;
+import st3ix.obfuscator.io.JarProcessor.ClassEntry;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Maps field names for obfuscation. Excludes serialVersionUID, enum constants,
+ * and fields in excluded packages.
+ */
+public final class FieldMapping {
+
+    private static final String[] LIBRARY_PREFIXES = {
+        "java/", "javax/", "jdk/", "sun/", "com/sun/",
+        "org/xml/", "org/w3c/",
+        "org/bukkit/", "org/spigotmc/", "net/minecraft/",
+        "io/papermc/", "com/destroystokyo/",
+        "org/apache/", "com/google/", "org/springframework/"
+    };
+
+    private static final String SERIAL_VERSION_UID = "serialVersionUID";
+    private static final String ENUM_SUPER = "java/lang/Enum";
+
+    private final List<String> excludePrefixes = new ArrayList<>();
+    private final Map<String, String> oldToNew = new HashMap<>();
+    private final List<FieldRenameEntry> renameEntries = new ArrayList<>();
+    private final NameGenerator nameGen;
+    private boolean excludeAll;
+    private final Map<String, ClassInfo> classInfos = new HashMap<>();
+
+    public FieldMapping(boolean namesRandom, int nameLength, boolean useHomoglyph, boolean useInvisibleChars) {
+        this.nameGen = new NameGenerator(namesRandom, nameLength, useHomoglyph, useInvisibleChars);
+        for (String p : LIBRARY_PREFIXES) {
+            excludePrefixes.add(p);
+        }
+    }
+
+    public void addExcludes(List<String> patterns) {
+        if (patterns == null) return;
+        for (String p : patterns) {
+            if (p == null || p.isBlank()) continue;
+            String trimmed = p.trim();
+            if ("*".equals(trimmed)) {
+                excludeAll = true;
+                return;
+            }
+            String internal = trimmed.replace('.', '/');
+            if (internal.endsWith("/*")) internal = internal.substring(0, internal.length() - 1);
+            if (!internal.endsWith("/")) internal += "/";
+            excludePrefixes.add(internal);
+        }
+    }
+
+    /**
+     * Builds the field mapping from all class bytes. Must be called before getNewName.
+     */
+    public void buildFrom(List<ClassEntry> classes) {
+        for (ClassEntry ce : classes) {
+            if (excludeAll || isExcluded(ce.internalName())) continue;
+            ClassReader cr = new ClassReader(ce.bytes());
+            ClassInfo info = new ClassInfo(ce.internalName());
+            cr.accept(new ClassVisitor(Opcodes.ASM9) {
+                @Override
+                public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+                    info.superName = superName;
+                    super.visit(version, access, name, signature, superName, interfaces);
+                }
+
+                @Override
+                public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
+                    info.fields.add(new FieldDef(name, descriptor, access));
+                    return super.visitField(access, name, descriptor, signature, value);
+                }
+            }, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG);
+            classInfos.put(ce.internalName(), info);
+        }
+
+        for (ClassEntry ce : classes) {
+            if (excludeAll || isExcluded(ce.internalName())) continue;
+            ClassInfo info = classInfos.get(ce.internalName());
+            if (info == null) continue;
+            for (FieldDef f : info.fields) {
+                if (!canRename(ce.internalName(), info.superName, f.name, f.desc, f.access)) continue;
+                String key = ce.internalName() + '.' + f.name + f.desc;
+                String newName = oldToNew.computeIfAbsent(key, k -> nameGen.next());
+                if (!f.name.equals(newName)) {
+                    renameEntries.add(new FieldRenameEntry(ce.internalName().replace('/', '.'), f.name, newName));
+                }
+            }
+        }
+    }
+
+    private boolean canRename(String owner, String superName, String name, String desc, int access) {
+        if (SERIAL_VERSION_UID.equals(name)) return false;
+        if (ENUM_SUPER.equals(superName)) {
+            String ownerType = "L" + owner + ";";
+            if ((access & Opcodes.ACC_STATIC) != 0 && (access & Opcodes.ACC_FINAL) != 0
+                && ownerType.equals(desc)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public String getNewName(String owner, String name, String descriptor) {
+        String key = owner + '.' + name + descriptor;
+        return oldToNew.getOrDefault(key, name);
+    }
+
+    /**
+     * Returns all field renames for logging.
+     */
+    public List<FieldRenameEntry> getRenameEntries() {
+        return new ArrayList<>(renameEntries);
+    }
+
+    public record FieldRenameEntry(String className, String oldName, String newName) {}
+
+    private boolean isExcluded(String internalName) {
+        for (String prefix : excludePrefixes) {
+            String base = prefix.endsWith("/") ? prefix.substring(0, prefix.length() - 1) : prefix;
+            if (internalName.equals(base) || internalName.startsWith(base + "/") || internalName.startsWith(base + "$")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static final class ClassInfo {
+        final String name;
+        String superName;
+        final List<FieldDef> fields = new ArrayList<>();
+
+        ClassInfo(String name) {
+            this.name = name;
+        }
+    }
+
+    private static final class FieldDef {
+        final String name;
+        final String desc;
+        final int access;
+
+        FieldDef(String name, String desc, int access) {
+            this.name = name;
+            this.desc = desc;
+            this.access = access;
+        }
+    }
+}

--- a/src/main/java/st3ix/obfuscator/transform/FieldRenamer.java
+++ b/src/main/java/st3ix/obfuscator/transform/FieldRenamer.java
@@ -1,0 +1,61 @@
+package st3ix.obfuscator.transform;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+/**
+ * Transforms class bytecode by renaming fields according to the given mapping.
+ */
+public final class FieldRenamer {
+
+    private final FieldMapping mapping;
+
+    public FieldRenamer(FieldMapping mapping) {
+        this.mapping = mapping;
+    }
+
+    /**
+     * Transforms the given class bytes. Returns the transformed bytes.
+     */
+    public byte[] transform(byte[] classBytes) {
+        ClassReader reader = new ClassReader(classBytes);
+        ClassWriter writer = new ClassWriter(reader, 0);
+        reader.accept(new FieldRenamerVisitor(writer), ClassReader.EXPAND_FRAMES);
+        return writer.toByteArray();
+    }
+
+    private final class FieldRenamerVisitor extends ClassVisitor {
+        private String ownerInternalName;
+
+        FieldRenamerVisitor(ClassVisitor cv) {
+            super(Opcodes.ASM9, cv);
+        }
+
+        @Override
+        public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+            ownerInternalName = name;
+            super.visit(version, access, name, signature, superName, interfaces);
+        }
+
+        @Override
+        public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
+            String newName = mapping.getNewName(ownerInternalName, name, descriptor);
+            return super.visitField(access, newName, descriptor, signature, value);
+        }
+
+        @Override
+        public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+            return new MethodVisitor(Opcodes.ASM9, super.visitMethod(access, name, descriptor, signature, exceptions)) {
+                @Override
+                public void visitFieldInsn(int opcode, String owner, String fieldName, String fieldDesc) {
+                    String mappedName = mapping.getNewName(owner, fieldName, fieldDesc);
+                    super.visitFieldInsn(opcode, owner, mappedName, fieldDesc);
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements field renaming and adds a verification demo class to confirm obfuscation works as expected.

## Changes

### Field Renaming
- **FieldMapping** – Builds field name mappings; excludes `serialVersionUID`, enum constants, and excluded packages
- **FieldRenamer** – Transforms `visitField` and `visitFieldInsn` (GETFIELD, PUTFIELD, GETSTATIC, PUTSTATIC)
- Config options: `fieldRenamingEnabled`, `fieldNamesRandom`, `fieldNameLength`, `fieldNamesHomoglyph`, `fieldNamesInvisibleChars`
- Integrated into `ObfuscationPipeline` (both with and without class renaming)
- GUI support: checkbox in Step 2 and field name options in Step 3
- Logs renames like method renaming (`Field renamed: className.field -> newName`)

### Verification Demo
- **ObfuscationVerifyDemo** – Simple class for quick obfuscation checks
- Includes numbers (25565, 12345, 1000), semantic locals (port, seed, threshold), and a field (apiKey)
- Clear before/after expectations for number obfuscation, debug stripping, and field renaming
- Wired into `Main` so it runs with the example JAR

### Other
- Updated `config.yml.example` with field renaming options
- Updated README with Field renaming and transform table

Closes #28 