### PR TITLE
feat(transform): replace XOR with number expression obfuscation for i…

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -9,7 +9,7 @@ methodRenamingEnabled: true
 # Enable or disable field renaming (excludes serialVersionUID, enum constants)
 fieldRenamingEnabled: true
 
-# Obfuscate numeric constants (int, long, float, double) using XOR
+# Obfuscate numeric constants (int = math expressions; long/float/double = XOR)
 numberObfuscationEnabled: true
 
 # Obfuscate array dimensions (new Type[n] -> n hidden with XOR)
@@ -42,8 +42,8 @@ fieldNameLength: 4         # minimum length of field names (1-32)
 fieldNamesHomoglyph: false # use lookalike chars for field names
 fieldNamesInvisibleChars: false  # inject zero-width chars in field names
 
-# Obfuscation keys (XOR)
-numberKeyRandom: false   # true = random key per build, false = fixed key
+# Obfuscation keys / randomization
+numberKeyRandom: false   # true = random expression pattern per value, false = deterministic
 arrayKeyRandom: false    # true = random key per build, false = fixed key
 booleanKeyRandom: false  # true = random key per build, false = fixed key
 stringKeyRandom: false   # true = random key per build, false = fixed key

--- a/src/main/java/st3ix/obfuscator/transform/NumberObfuscator.java
+++ b/src/main/java/st3ix/obfuscator/transform/NumberObfuscator.java
@@ -9,9 +9,10 @@ import org.objectweb.asm.Opcodes;
 import java.util.Random;
 
 /**
- * Obfuscates integer, long, float and double constants in bytecode using XOR.
- * Replaces ldc N with (N ^ key) ^ key to hide the original value.
- * For float/double, the bit representation is XORed and reconstructed at runtime.
+ * Obfuscates numeric constants in bytecode using math expression obfuscation.
+ * Replaces simple constants like 123 with expressions such as (50 * 3) - 27,
+ * so decompilers show the expression instead of the original value and compilers
+ * cannot constant-fold as easily. Float/double/long still use XOR for now.
  */
 public final class NumberObfuscator {
 
@@ -20,28 +21,31 @@ public final class NumberObfuscator {
 
     private final int intKey;
     private final long longKey;
+    private final Random rng;
 
     /**
-     * Creates an obfuscator with default (fixed) keys.
+     * Creates an obfuscator with fixed expression pattern (deterministic per value).
      */
     public NumberObfuscator() {
         this.intKey = DEFAULT_INT_KEY;
         this.longKey = DEFAULT_LONG_KEY;
+        this.rng = null;
     }
 
     /**
-     * Creates an obfuscator with random keys (different per instance).
+     * Creates an obfuscator that randomizes expression patterns per value.
      */
     public static NumberObfuscator withRandomKey() {
         Random r = new Random();
         int ik = r.nextInt();
         long lk = ((long) r.nextInt() << 32) | (r.nextInt() & 0xFFFFFFFFL);
-        return new NumberObfuscator(ik, lk);
+        return new NumberObfuscator(ik, lk, r);
     }
 
-    private NumberObfuscator(int intKey, long longKey) {
+    private NumberObfuscator(int intKey, long longKey, Random rng) {
         this.intKey = intKey;
         this.longKey = longKey;
+        this.rng = rng;
     }
 
     /**
@@ -50,7 +54,7 @@ public final class NumberObfuscator {
     public byte[] transform(byte[] classBytes) {
         ClassReader reader = new ClassReader(classBytes);
         ClassWriter writer = new ClassWriter(reader, ClassWriter.COMPUTE_FRAMES);
-        reader.accept(new NumberObfuscatorClassVisitor(writer, intKey, longKey), ClassReader.EXPAND_FRAMES);
+        reader.accept(new NumberObfuscatorClassVisitor(writer, intKey, longKey, rng), ClassReader.EXPAND_FRAMES);
         return writer.toByteArray();
     }
 
@@ -58,18 +62,20 @@ public final class NumberObfuscator {
 
         private final int intKey;
         private final long longKey;
+        private final Random rng;
 
-        NumberObfuscatorClassVisitor(ClassVisitor cv, int intKey, long longKey) {
+        NumberObfuscatorClassVisitor(ClassVisitor cv, int intKey, long longKey, Random rng) {
             super(Opcodes.ASM9, cv);
             this.intKey = intKey;
             this.longKey = longKey;
+            this.rng = rng;
         }
 
         @Override
         public MethodVisitor visitMethod(int access, String name, String descriptor,
                                          String signature, String[] exceptions) {
             MethodVisitor mv = super.visitMethod(access, name, descriptor, signature, exceptions);
-            return new NumberObfuscatorMethodVisitor(mv, intKey, longKey);
+            return new NumberObfuscatorMethodVisitor(mv, intKey, longKey, rng);
         }
     }
 
@@ -77,17 +83,19 @@ public final class NumberObfuscator {
 
         private final int intKey;
         private final long longKey;
+        private final Random rng;
 
-        NumberObfuscatorMethodVisitor(MethodVisitor mv, int intKey, long longKey) {
+        NumberObfuscatorMethodVisitor(MethodVisitor mv, int intKey, long longKey, Random rng) {
             super(Opcodes.ASM9, mv);
             this.intKey = intKey;
             this.longKey = longKey;
+            this.rng = rng;
         }
 
         @Override
         public void visitIntInsn(int opcode, int operand) {
             if (opcode == Opcodes.BIPUSH || opcode == Opcodes.SIPUSH) {
-                emitXorInt(operand);
+                emitIntExpression(operand);
             } else {
                 super.visitIntInsn(opcode, operand);
             }
@@ -96,7 +104,7 @@ public final class NumberObfuscator {
         @Override
         public void visitLdcInsn(Object value) {
             if (value instanceof Integer i) {
-                emitXorInt(i);
+                emitIntExpression(i);
             } else if (value instanceof Long l) {
                 emitXorLong(l);
             } else if (value instanceof Float f) {
@@ -123,6 +131,150 @@ public final class NumberObfuscator {
             super.visitLdcInsn(obfuscated);
             super.visitLdcInsn(longKey);
             super.visitInsn(Opcodes.LXOR);
+        }
+
+        private void emitIntExpression(int value) {
+            if (tryEmitExpression(value)) {
+                return;
+            }
+            emitXorInt(value);
+        }
+
+        private boolean tryEmitExpression(int value) {
+            int strategy = rng != null ? rng.nextInt(5) : (Math.abs(value) % 5);
+            return switch (strategy) {
+                case 0 -> emitAdd(value);
+                case 1 -> emitMulAdd(value);
+                case 2 -> emitSub(value);
+                case 3 -> emitShiftAdd(value);
+                case 4 -> emitMulSub(value);
+                default -> emitAdd(value);
+            };
+        }
+
+        private void emitLdcInt(int v) {
+            if (v >= -1 && v <= 5) {
+                int opcode = switch (v) {
+                    case -1 -> Opcodes.ICONST_M1;
+                    case 0 -> Opcodes.ICONST_0;
+                    case 1 -> Opcodes.ICONST_1;
+                    case 2 -> Opcodes.ICONST_2;
+                    case 3 -> Opcodes.ICONST_3;
+                    case 4 -> Opcodes.ICONST_4;
+                    case 5 -> Opcodes.ICONST_5;
+                    default -> -1;
+                };
+                if (opcode != -1) {
+                    super.visitInsn(opcode);
+                    return;
+                }
+            }
+            if (v >= Byte.MIN_VALUE && v <= Byte.MAX_VALUE) {
+                super.visitIntInsn(Opcodes.BIPUSH, v);
+            } else if (v >= Short.MIN_VALUE && v <= Short.MAX_VALUE) {
+                super.visitIntInsn(Opcodes.SIPUSH, v);
+            } else {
+                super.visitLdcInsn(v);
+            }
+        }
+
+        private boolean emitAdd(int value) {
+            int a;
+            if (rng != null) {
+                a = rng.nextInt(2001) - 1000;
+                if (value >= 0 && a > value) a = value;
+                if (value < 0 && a < value) a = value;
+            } else {
+                a = (Math.abs(value) % 500) + 1;
+                if (value < 0) a = -a;
+                if ((long) a + (long) (value - a) != value) a = value / 2;
+            }
+            long b = (long) value - (long) a;
+            if (b < Integer.MIN_VALUE || b > Integer.MAX_VALUE) return false;
+            emitLdcInt(a);
+            emitLdcInt((int) b);
+            super.visitInsn(Opcodes.IADD);
+            return true;
+        }
+
+        private boolean emitMulAdd(int value) {
+            if (value == 0) {
+                emitLdcInt(1);
+                emitLdcInt(0);
+                super.visitInsn(Opcodes.IMUL);
+                return true;
+            }
+            int a = (rng != null ? rng.nextInt(49) + 2 : 17) & 0xFF;
+            if (a <= 0) a = 2;
+            int b = value / a;
+            int c = value - a * b;
+            long prod = (long) a * (long) b;
+            if (prod != (int) prod) return false;
+            if ((long) a * b + c != value) return false;
+            emitLdcInt(a);
+            emitLdcInt(b);
+            super.visitInsn(Opcodes.IMUL);
+            if (c != 0) {
+                emitLdcInt(c);
+                super.visitInsn(Opcodes.IADD);
+            }
+            return true;
+        }
+
+        private boolean emitSub(int value) {
+            int k = rng != null ? rng.nextInt(500) + 1 : Math.abs(value % 100) + 1;
+            long a = (long) value + (long) k;
+            if (a < Integer.MIN_VALUE || a > Integer.MAX_VALUE) return false;
+            emitLdcInt((int) a);
+            emitLdcInt(k);
+            super.visitInsn(Opcodes.ISUB);
+            return true;
+        }
+
+        private boolean emitShiftAdd(int value) {
+            if (value < 0) return false;
+            int n = rng != null ? rng.nextInt(4) + 1 : (value % 4) + 1;
+            int shift = 1 << n;
+            int a = value / shift;
+            int b = value % shift;
+            if (value == Integer.MAX_VALUE && n == 1) return false;
+            emitLdcInt(a);
+            emitLdcInt(n);
+            super.visitInsn(Opcodes.ISHL);
+            if (b != 0) {
+                emitLdcInt(b);
+                super.visitInsn(Opcodes.IADD);
+            }
+            return true;
+        }
+
+        private boolean emitMulSub(int value) {
+            if (value == Integer.MIN_VALUE) {
+                emitLdcInt(1);
+                emitLdcInt(31);
+                super.visitInsn(Opcodes.ISHL);
+                return true;
+            }
+            if (value == Integer.MAX_VALUE) {
+                emitLdcInt(1);
+                emitLdcInt(31);
+                super.visitInsn(Opcodes.ISHL);
+                emitLdcInt(1);
+                super.visitInsn(Opcodes.ISUB);
+                return true;
+            }
+            int a = (rng != null ? rng.nextInt(30) + 2 : 7) & 0xFF;
+            int b = (rng != null ? rng.nextInt(30) + 2 : 11) & 0xFF;
+            long prod = (long) a * (long) b;
+            if (prod < Integer.MIN_VALUE || prod > Integer.MAX_VALUE) return false;
+            int c = (int) prod - value;
+            if (c < 0) return false;
+            emitLdcInt(a);
+            emitLdcInt(b);
+            super.visitInsn(Opcodes.IMUL);
+            emitLdcInt(c);
+            super.visitInsn(Opcodes.ISUB);
+            return true;
         }
 
         private void emitXorInt(int value) {


### PR DESCRIPTION
## Summary

Replaces weak XOR-based number obfuscation with **math expression obfuscation** for integer constants. Decompilers now show expressions like `(50 * 3) - 27` instead of `123`, and the pattern is less prone to compiler constant folding.

## Changes

- **Integer obfuscation**: Uses multiple decomposition strategies:
  - `a + b` / `a - b` (linear)
  - `a * b + c` (multiply-add)
  - `(a << n) + b` (shift-add)
  - `a * b - c` (multiply-subtract)
  - Edge cases: `0` → `1*0`, `Integer.MIN_VALUE` → `1<<31`, `Integer.MAX_VALUE` → `(1<<31)-1`
- **Float/Double/Long**: Remain XOR-based (unchanged)
- **Config**: `numberKeyRandom` now controls expression pattern randomization (was: XOR key randomness)

## Files Changed

- `src/main/java/st3ix/obfuscator/transform/NumberObfuscator.java` – full rewrite for expression obfuscation
- `config.yml.example` – updated comments for number obfuscation
- `docs/issue-number-expression-obfuscation.md` – issue template (reference)

## Testing

- Obfuscated Example project runs correctly (port=25565, seed=12345, threshold=1000)
- Build successful

Closes #32 
