### PR TITLE
feat(transform): per-class and per-string keys for string obfuscation

### DIFF
--- a/Features.md
+++ b/Features.md
@@ -15,7 +15,7 @@
 - **Number obfuscation** – Hides `int` constants via math expressions (`123` → `(50*3)-27`, `(a<<n)+b`, etc.); decompilers show expressions, not literals. `long`/`float`/`double` still use XOR. Less prone to constant folding than simple XOR.
 - **Array dimension obfuscation** – Hides array sizes (`new int[8]` → `new int[(8 ^ key) ^ key]`)
 - **Boolean obfuscation** – Hides `true`/`false` literals using XOR (`ICONST_0`/`ICONST_1` → `(value ^ key) ^ key`)
-- **String obfuscation** – Encrypts string literals using XOR; **decryption inlined at each use site** (no central decoder class). No single method to hook and dump all strings. Runtime-derived keys for `static final` fields. Strong against `strings`-tools and casual inspection. **Note:** Determined reversers can still trace decryption logic – obfuscation raises the bar, not unbreakable.
+- **String obfuscation** – Encrypts string literals using XOR; **decryption inlined at each use site** (no central decoder class). **Key per class and per string**: each string uses `key ^ class.hashCode() ^ index`, so no global key and different strings get different keys. Strong against `strings`-tools and casual inspection. **Note:** Determined reversers can still trace decryption logic – obfuscation raises the bar, not unbreakable.
 - **Optional random keys** – `numberKeyRandom`, `arrayKeyRandom`, `booleanKeyRandom`, `stringKeyRandom` for different keys/patterns per build
 - **Debug info stripping** – Removes source file names, line number table, and local variable table. Decompilers show `var0`, `var1`, etc., and lose source mappings. Configurable via `debugInfoStrippingEnabled`.
 

--- a/src/main/java/st3ix/obfuscator/transform/StringObfuscator.java
+++ b/src/main/java/st3ix/obfuscator/transform/StringObfuscator.java
@@ -14,6 +14,7 @@ import java.util.Random;
  * Obfuscates string literals in bytecode using XOR encryption.
  * Replaces LDC "string" with inline decryption bytecode at each call site.
  * No central decoder class – no single point to hook and dump all strings.
+ * Key per class (owner.hashCode) and per string (index in method) for stronger obfuscation.
  */
 public final class StringObfuscator {
 
@@ -92,8 +93,7 @@ public final class StringObfuscator {
         public MethodVisitor visitMethod(int access, String name, String descriptor,
                                          String signature, String[] exceptions) {
             MethodVisitor mv = super.visitMethod(access, name, descriptor, signature, exceptions);
-            boolean isClinit = "<clinit>".equals(name);
-            return new StringObfuscatorMethodVisitor(mv, key, owner, isClinit);
+            return new StringObfuscatorMethodVisitor(mv, key, owner);
         }
     }
 
@@ -101,13 +101,12 @@ public final class StringObfuscator {
 
         private final int key;
         private final String owner;
-        private final boolean useRuntimeKey;
+        private int stringIndex;
 
-        StringObfuscatorMethodVisitor(MethodVisitor mv, int key, String owner, boolean useRuntimeKey) {
+        StringObfuscatorMethodVisitor(MethodVisitor mv, int key, String owner) {
             super(Opcodes.ASM9, mv);
             this.key = key;
             this.owner = owner;
-            this.useRuntimeKey = useRuntimeKey;
         }
 
         @Override
@@ -120,14 +119,11 @@ public final class StringObfuscator {
         }
 
         private void emitEncryptedString(String s) {
-            int actualKey = useRuntimeKey ? key ^ owner.hashCode() : key;
+            int idx = stringIndex++;
+            int actualKey = key ^ owner.hashCode() ^ idx;
             byte[] encrypted = encrypt(s, actualKey);
             emitByteArray(encrypted);
-            if (useRuntimeKey) {
-                emitRuntimeKey();
-            } else {
-                super.visitLdcInsn(key);
-            }
+            emitRuntimeKey(idx);
             emitInlineDecrypt();
         }
 
@@ -173,12 +169,12 @@ public final class StringObfuscator {
             super.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/String", "<init>", "([BLjava/nio/charset/Charset;)V", false);
         }
 
-        /** Emits: key ^ thisClass.getName().hashCode() - prevents static evaluation by decompilers */
-        private void emitRuntimeKey() {
+        /** Emits: (key ^ stringIndex) ^ thisClass.getName().hashCode() = actualKey per class and per string */
+        private void emitRuntimeKey(int stringIndex) {
             super.visitLdcInsn(Type.getObjectType(owner));
             super.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "java/lang/Class", "getName", "()Ljava/lang/String;", false);
             super.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "java/lang/String", "hashCode", "()I", false);
-            super.visitLdcInsn(key);
+            super.visitLdcInsn(key ^ stringIndex);
             super.visitInsn(Opcodes.IXOR);
         }
 


### PR DESCRIPTION
## Summary

String obfuscation now uses a **unique key per string** and **per class** instead of a shared key.
Each string literal gets `actualKey = key ^ owner.hashCode() ^ stringIndex`, making bulk key
recovery harder.

## Changes

- **StringObfuscator**: Add `stringIndex` counter; use `key ^ owner.hashCode() ^ stringIndex` for all strings
- **emitRuntimeKey(int stringIndex)**: Emit `(key ^ stringIndex) ^ class.getName().hashCode()`
- Remove `useRuntimeKey` branch; runtime key derivation used for all strings

## Before vs After

| Aspect | Before | After |
|--------|--------|-------|
| Key per class | Only in `<clinit>` | All strings |
| Key per string | No | Yes (index 0, 1, 2, …) |
| Decompiled key constants | Same for all | Different per string (0x????C75C, 0x????C75D, …) |

## Files Changed

- `src/main/java/st3ix/obfuscator/transform/StringObfuscator.java`

## Testing

- Obfuscated Example JAR runs correctly
- Decompiled output shows `class.getName().hashCode() ^ 0x????` with varying hex constants per string

Closes #36 