### PR TITLE
feat: Flow obfuscation + Logger improvements

### DIFF
--- a/Example/Java Project/build.gradle.kts
+++ b/Example/Java Project/build.gradle.kts
@@ -25,7 +25,7 @@ tasks.jar {
     }
 }
 
-val obfuscatorJar = file("../../build/dist/st3ix-obfuscator.jar")
+val obfuscatorJar = file("../../build/dist/st3ix-obfuscator-v1.0.3.jar")
 
 tasks.register<JavaExec>("obfuscate") {
     dependsOn(tasks.jar)

--- a/Example/Java Project/src/main/java/example/CrossRefTest.java
+++ b/Example/Java Project/src/main/java/example/CrossRefTest.java
@@ -21,6 +21,8 @@ public final class CrossRefTest {
         service.run();
         String reversed = StringHelper.reverse("cross-ref");
         System.out.println("Reversed: " + reversed);
+        String formatted = StringHelper.formatIdLinear(user.getId());
+        System.out.println("Formatted: " + formatted);
         System.out.println("User: " + user);
     }
 }

--- a/Example/Java Project/src/main/java/example/DemoService.java
+++ b/Example/Java Project/src/main/java/example/DemoService.java
@@ -12,6 +12,8 @@ public final class DemoService {
         counter++;
         String message = buildMessage("Hello", "World");
         System.out.println(message);
+        int hash = computeHash(42);
+        System.out.println("Hash(42)=" + hash);
         processData(42, true);
         printMagicNumbers();
         printArrayDemo();
@@ -58,5 +60,16 @@ public final class DemoService {
 
     public String getSecretKey() {
         return SECRET_KEY;
+    }
+
+    /**
+     * Linear method for flow obfuscation demo: pure arithmetic chain.
+     */
+    public int computeHash(int x) {
+        int a = x * 31;
+        int b = a + 17;
+        int c = b / 7;
+        int d = c - 3;
+        return d * 11;
     }
 }

--- a/Example/Java Project/src/main/java/example/FlowObfuscationDemo.java
+++ b/Example/Java Project/src/main/java/example/FlowObfuscationDemo.java
@@ -1,0 +1,60 @@
+package example;
+
+/**
+ * Demo class specifically designed to test flow obfuscation.
+ *
+ * Flow obfuscation flattens the control flow into a switch-dispatcher structure.
+ * To be eligible, methods must be:
+ * - Linear (no if/else, for, while, switch)
+ * - Have at least 8 instructions (after other obfuscations)
+ * - No try-catch blocks
+ *
+ * After obfuscation with flow enabled, decompile this class and look for
+ * switch statements in the method bodies.
+ */
+public final class FlowObfuscationDemo {
+
+    /**
+     * Linear method: pure arithmetic, no branches.
+     * Should produce a switch-based flattened structure when flow obfuscation is applied.
+     */
+    public int linearCompute(int a, int b) {
+        int step1 = a * 2;
+        int step2 = step1 + b;
+        int step3 = step2 / 3;
+        int step4 = step3 - 7;
+        int step5 = step4 * 11;
+        return step5;
+    }
+
+    /**
+     * Another linear method with more instructions.
+     */
+    public String linearBuildString(int id) {
+        String part1 = "id=";
+        String part2 = String.valueOf(id);
+        String part3 = "; processed";
+        String result = part1 + part2 + part3;
+        return result;
+    }
+
+    /**
+     * Linear method that returns a computed value.
+     */
+    public long linearTimestamp(int base) {
+        long t1 = base * 1000L;
+        long t2 = t1 + 500L;
+        long t3 = t2 / 2L;
+        return t3;
+    }
+
+    /**
+     * Entry point - call from Main to exercise these methods.
+     */
+    public void run() {
+        int x = linearCompute(10, 20);
+        String s = linearBuildString(x);
+        long t = linearTimestamp(x);
+        System.out.println("FlowObfuscationDemo: " + s + " ts=" + t);
+    }
+}

--- a/Example/Java Project/src/main/java/example/Main.java
+++ b/Example/Java Project/src/main/java/example/Main.java
@@ -11,6 +11,7 @@ public final class Main {
         service.run();
         new DebugStrippingDemo().demonstrateLocalVariables();
         new ObfuscationVerifyDemo().verify();
+        new FlowObfuscationDemo().run();
         CrossRefTest crossRef = new CrossRefTest();
         crossRef.run();
     }

--- a/Example/Java Project/src/main/java/example/ObfuscationVerifyDemo.java
+++ b/Example/Java Project/src/main/java/example/ObfuscationVerifyDemo.java
@@ -31,8 +31,10 @@ public final class ObfuscationVerifyDemo {
         int port = 25565;
         int seed = 12345;
         int threshold = 1000;
+        int sum = port + seed + threshold;
 
         System.out.println("ObfuscationVerifyDemo: port=" + port + ", seed=" + seed + ", threshold=" + threshold);
+        System.out.println("Sum=" + sum);
         System.out.println("Field (apiKey): " + apiKey);
     }
 }

--- a/Example/Java Project/src/main/java/example/model/User.java
+++ b/Example/Java Project/src/main/java/example/model/User.java
@@ -32,4 +32,13 @@ public final class User {
     public String toString() {
         return "User{name='" + name + "', id=" + id + "}";
     }
+
+    /**
+     * Linear method for flow obfuscation demo: builds display string without branches.
+     */
+    public String toDisplayString() {
+        String part1 = name + "#";
+        String part2 = part1 + id;
+        return part2;
+    }
 }

--- a/Example/Java Project/src/main/java/example/util/StringHelper.java
+++ b/Example/Java Project/src/main/java/example/util/StringHelper.java
@@ -22,4 +22,14 @@ public final class StringHelper {
         }
         return false;
     }
+
+    /**
+     * Linear method for flow obfuscation demo: formats id as "id=N;" without branches.
+     */
+    public static String formatIdLinear(int id) {
+        String prefix = "id=";
+        String num = String.valueOf(id);
+        String suffix = ";";
+        return prefix + num + suffix;
+    }
 }

--- a/config.yml.example
+++ b/config.yml.example
@@ -21,6 +21,9 @@ booleanObfuscationEnabled: true
 # Obfuscate string literals (encrypt at build time, decrypt at runtime)
 stringObfuscationEnabled: true
 
+# Control flow obfuscation (flatten method control flow via switch dispatcher)
+flowObfuscationEnabled: false
+
 # Strip debug info (source file, line numbers, local variable names)
 debugInfoStrippingEnabled: true
 
@@ -47,6 +50,7 @@ numberKeyRandom: false   # true = random expression pattern per value, false = d
 arrayKeyRandom: false    # true = random key per build, false = fixed key
 booleanKeyRandom: false  # true = random key per build, false = fixed key
 stringKeyRandom: false   # true = random key per build, false = fixed key
+flowKeyRandom: false    # true = random key per build, false = fixed key
 
 # Classes/packages to exclude from renaming.
 # Use "*" to exclude ALL classes (no renaming). Prefix: com.example excludes com.example.*

--- a/src/main/java/st3ix/obfuscator/config/ConfigLoader.java
+++ b/src/main/java/st3ix/obfuscator/config/ConfigLoader.java
@@ -60,15 +60,17 @@ public final class ConfigLoader {
             boolean arrayKeyRandom = getBoolean(raw, "arrayKeyRandom", false);
             boolean booleanKeyRandom = getBoolean(raw, "booleanKeyRandom", false);
             boolean stringKeyRandom = getBoolean(raw, "stringKeyRandom", false);
+            boolean flowObfuscationEnabled = getBoolean(raw, "flowObfuscationEnabled", false);
+            boolean flowKeyRandom = getBoolean(raw, "flowKeyRandom", false);
             List<String> excludeClasses = getStringList(raw, "excludeClasses");
 
             return new LoadResult(new ObfuscatorConfig(
                 classRenamingEnabled, methodRenamingEnabled, fieldRenamingEnabled, numberObfuscationEnabled, arrayObfuscationEnabled,
-                booleanObfuscationEnabled, stringObfuscationEnabled, debugInfoStrippingEnabled,
+                booleanObfuscationEnabled, stringObfuscationEnabled, flowObfuscationEnabled, debugInfoStrippingEnabled,
                 classNamesRandom, classNameLength, classNamesHomoglyph, classNamesInvisibleChars,
                 methodNamesRandom, methodNameLength, methodNamesHomoglyph, methodNamesInvisibleChars,
                 fieldNamesRandom, fieldNameLength, fieldNamesHomoglyph, fieldNamesInvisibleChars,
-                numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, excludeClasses
+                numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, flowKeyRandom, excludeClasses
             ), configPath);
         } catch (Exception e) {
             return new LoadResult(ObfuscatorConfig.defaults(), null);
@@ -114,14 +116,16 @@ public final class ConfigLoader {
             boolean arrayKeyRandom = getBoolean(raw, "arrayKeyRandom", false);
             boolean booleanKeyRandom = getBoolean(raw, "booleanKeyRandom", false);
             boolean stringKeyRandom = getBoolean(raw, "stringKeyRandom", false);
+            boolean flowObfuscationEnabled = getBoolean(raw, "flowObfuscationEnabled", false);
+            boolean flowKeyRandom = getBoolean(raw, "flowKeyRandom", false);
             List<String> excludeClasses = getStringList(raw, "excludeClasses");
             return new LoadResult(new ObfuscatorConfig(
                 classRenamingEnabled, methodRenamingEnabled, fieldRenamingEnabled, numberObfuscationEnabled, arrayObfuscationEnabled,
-                booleanObfuscationEnabled, stringObfuscationEnabled, debugInfoStrippingEnabled,
+                booleanObfuscationEnabled, stringObfuscationEnabled, flowObfuscationEnabled, debugInfoStrippingEnabled,
                 classNamesRandom, classNameLength, classNamesHomoglyph, classNamesInvisibleChars,
                 methodNamesRandom, methodNameLength, methodNamesHomoglyph, methodNamesInvisibleChars,
                 fieldNamesRandom, fieldNameLength, fieldNamesHomoglyph, fieldNamesInvisibleChars,
-                numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, excludeClasses
+                numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, flowKeyRandom, excludeClasses
             ), configPath);
         } catch (Exception e) {
             throw new IOException("Config format invalid: " + e.getMessage());

--- a/src/main/java/st3ix/obfuscator/config/ObfuscatorConfig.java
+++ b/src/main/java/st3ix/obfuscator/config/ObfuscatorConfig.java
@@ -14,6 +14,7 @@ public record ObfuscatorConfig(
     boolean arrayObfuscationEnabled,
     boolean booleanObfuscationEnabled,
     boolean stringObfuscationEnabled,
+    boolean flowObfuscationEnabled,
     boolean debugInfoStrippingEnabled,
     boolean classNamesRandom,
     int classNameLength,
@@ -31,6 +32,7 @@ public record ObfuscatorConfig(
     boolean arrayKeyRandom,
     boolean booleanKeyRandom,
     boolean stringKeyRandom,
+    boolean flowKeyRandom,
     List<String> excludeClasses
 ) {
     private static final int DEFAULT_CLASS_NAME_LENGTH = 6;
@@ -49,10 +51,10 @@ public record ObfuscatorConfig(
     }
 
     public static ObfuscatorConfig defaults() {
-        return new ObfuscatorConfig(true, true, true, true, true, true, true, true,
+        return new ObfuscatorConfig(true, true, true, true, true, true, true, false, true,
             false, DEFAULT_CLASS_NAME_LENGTH, false, false,
             false, DEFAULT_METHOD_NAME_LENGTH, false, false,
             false, DEFAULT_FIELD_NAME_LENGTH, false, false,
-            false, false, false, false, List.of());
+            false, false, false, false, false, List.of());
     }
 }

--- a/src/main/java/st3ix/obfuscator/core/ObfuscationPipeline.java
+++ b/src/main/java/st3ix/obfuscator/core/ObfuscationPipeline.java
@@ -9,6 +9,7 @@ import st3ix.obfuscator.log.Logger;
 import st3ix.obfuscator.transform.ArrayObfuscator;
 import st3ix.obfuscator.transform.BooleanObfuscator;
 import st3ix.obfuscator.transform.ClassMapping;
+import st3ix.obfuscator.transform.FlowObfuscator;
 import st3ix.obfuscator.transform.ClassRenamer;
 import st3ix.obfuscator.transform.DebugInfoStripper;
 import st3ix.obfuscator.transform.FieldMapping;
@@ -23,6 +24,12 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
@@ -49,7 +56,7 @@ public final class ObfuscationPipeline {
                 int totalSteps = (config.methodRenamingEnabled() ? 1 : 0) + (config.fieldRenamingEnabled() ? 1 : 0)
                     + (config.numberObfuscationEnabled() ? 1 : 0) + (config.arrayObfuscationEnabled() ? 1 : 0)
                     + (config.booleanObfuscationEnabled() ? 1 : 0) + (config.stringObfuscationEnabled() ? 1 : 0)
-                    + (config.debugInfoStrippingEnabled() ? 1 : 0) + 1;
+                    + (config.flowObfuscationEnabled() ? 1 : 0) + (config.debugInfoStrippingEnabled() ? 1 : 0) + 1;
                 if (config.methodRenamingEnabled()) {
                     Logger.step("Step %d/%d: Method renaming", stepNum++, totalSteps);
                     MethodMapping methodMapping = new MethodMapping(config.methodNamesRandom(), config.methodNameLength(),
@@ -112,6 +119,14 @@ public final class ObfuscationPipeline {
                         .toList();
                     Logger.success("String obfuscation applied");
                 }
+                if (config.flowObfuscationEnabled()) {
+                    Logger.step("Step %d/%d: Flow obfuscation", stepNum++, totalSteps);
+                    FlowObfuscator fo = config.flowKeyRandom() ? FlowObfuscator.withRandomKey() : new FlowObfuscator();
+                    classesToWrite = classesToWrite.stream()
+                        .map(ce -> new ClassEntry(ce.path(), ce.internalName(), fo.transform(ce.bytes())))
+                        .toList();
+                    Logger.success("Flow obfuscation applied");
+                }
                 if (config.debugInfoStrippingEnabled()) {
                     Logger.step("Step %d/%d: Debug info stripping", stepNum++, totalSteps);
                     DebugInfoStripper dis = new DebugInfoStripper();
@@ -153,9 +168,10 @@ public final class ObfuscationPipeline {
         boolean arrayObfEnabled = config.arrayObfuscationEnabled();
         boolean booleanObfEnabled = config.booleanObfuscationEnabled();
         boolean stringObfEnabled = config.stringObfuscationEnabled();
+        boolean flowObfEnabled = config.flowObfuscationEnabled();
         boolean debugInfoStrippingEnabled = config.debugInfoStrippingEnabled();
         int totalSteps = 2 + (methodObfEnabled ? 1 : 0) + (fieldObfEnabled ? 1 : 0) + (numberObfEnabled ? 1 : 0) + (arrayObfEnabled ? 1 : 0)
-            + (booleanObfEnabled ? 1 : 0) + (stringObfEnabled ? 1 : 0) + (debugInfoStrippingEnabled ? 1 : 0);
+            + (booleanObfEnabled ? 1 : 0) + (stringObfEnabled ? 1 : 0) + (flowObfEnabled ? 1 : 0) + (debugInfoStrippingEnabled ? 1 : 0);
         int stepNum = 1;
 
         MethodMapping methodMapping = null;
@@ -202,6 +218,9 @@ public final class ObfuscationPipeline {
         StringObfuscator stringObfuscator = stringObfEnabled
             ? (config.stringKeyRandom() ? StringObfuscator.withRandomKey() : new StringObfuscator())
             : null;
+        FlowObfuscator flowObfuscator = flowObfEnabled
+            ? (config.flowKeyRandom() ? FlowObfuscator.withRandomKey() : new FlowObfuscator())
+            : null;
         List<ClassEntry> transformed = new ArrayList<>();
         int renamedCount = 0;
         for (ClassEntry ce : contents.classes()) {
@@ -212,6 +231,8 @@ public final class ObfuscationPipeline {
                 renamedCount++;
             }
             byte[] bytes = ce.bytes();
+            String cn = ce.internalName().replace('/', '.');
+            Logger.info("  Transforming: %s", cn);
             if (methodObfEnabled) {
                 bytes = methodRenamer.transform(bytes);
             }
@@ -230,6 +251,26 @@ public final class ObfuscationPipeline {
             }
             if (stringObfEnabled) {
                 bytes = stringObfuscator.transform(bytes);
+            }
+            if (flowObfEnabled) {
+                try {
+                    Logger.flowTransform("  Flow transform: %s ...", cn);
+                    ExecutorService exec = Executors.newSingleThreadExecutor();
+                    byte[] inputBytes = bytes;
+                    Future<byte[]> future = exec.submit(() -> flowObfuscator.transform(inputBytes));
+                    try {
+                        bytes = future.get(30, TimeUnit.SECONDS);
+                        Logger.flowTransform("  Flow transform: %s OK", cn);
+                    } catch (TimeoutException e) {
+                        future.cancel(true);
+                        Logger.warn(String.format("  Flow obfuscation timed out for %s (skipped)", cn));
+                    } finally {
+                        exec.shutdownNow();
+                    }
+                } catch (Throwable ex) {
+                    Logger.warn(String.format("  Flow obfuscation skipped for %s: %s", cn, ex.getMessage()));
+                    ex.printStackTrace(System.err);
+                }
             }
             if (debugInfoStrippingEnabled) {
                 bytes = new DebugInfoStripper().transform(bytes);
@@ -254,6 +295,10 @@ public final class ObfuscationPipeline {
         if (stringObfEnabled) {
             Logger.step("Step %d/%d: String obfuscation", stepNum++, totalSteps);
             Logger.success("String obfuscation applied");
+        }
+        if (flowObfEnabled) {
+            Logger.step("Step %d/%d: Flow obfuscation", stepNum++, totalSteps);
+            Logger.success("Flow obfuscation applied");
         }
         if (debugInfoStrippingEnabled) {
             Logger.step("Step %d/%d: Debug info stripping", stepNum++, totalSteps);

--- a/src/main/java/st3ix/obfuscator/gui/ObfuscatorGui.java
+++ b/src/main/java/st3ix/obfuscator/gui/ObfuscatorGui.java
@@ -79,6 +79,7 @@ public final class ObfuscatorGui {
             JCheckBox arrayObf = new JCheckBox("Array obfuscation", true);
             JCheckBox booleanObf = new JCheckBox("Boolean obfuscation", true);
             JCheckBox stringObf = new JCheckBox("String obfuscation", true);
+            JCheckBox flowObf = new JCheckBox("Flow obfuscation", false);
             JCheckBox debugInfoStrip = new JCheckBox("Strip debug info", true);
             JCheckBox classNamesRandom = new JCheckBox("Random class names", false);
             JCheckBox classNamesHomoglyph = new JCheckBox("Homoglyph class names", false);
@@ -87,6 +88,7 @@ public final class ObfuscatorGui {
             JCheckBox arrayKeyRandom = new JCheckBox("Random array key", false);
             JCheckBox booleanKeyRandom = new JCheckBox("Random boolean key", false);
             JCheckBox stringKeyRandom = new JCheckBox("Random string key", false);
+            JCheckBox flowKeyRandom = new JCheckBox("Random flow key", false);
             JSpinner classNameLength = new JSpinner(new SpinnerNumberModel(6, 1, 32, 1));
             classNameLength.setPreferredSize(new Dimension(60, 24));
             JSpinner methodNameLength = new JSpinner(new SpinnerNumberModel(4, 1, 32, 1));
@@ -161,24 +163,24 @@ public final class ObfuscatorGui {
             content.add(step1, STEP_INPUT);
 
             // Step 2: Obfuscation
-            JPanel step2 = buildStep2Panel(classRename, methodRename, fieldRename, numberObf, arrayObf, booleanObf, stringObf, debugInfoStrip, classNameLength, methodNameLength, fieldNameLength);
+            JPanel step2 = buildStep2Panel(classRename, methodRename, fieldRename, numberObf, arrayObf, booleanObf, stringObf, flowObf, debugInfoStrip, classNameLength, methodNameLength, fieldNameLength);
             content.add(step2, STEP_OBFUSCATION);
 
             // Step 3: Advanced
             JPanel step3 = buildStep3Panel(classNamesRandom, classNamesHomoglyph, classNamesInvisibleChars,
                 methodNamesRandom, methodNamesHomoglyph, methodNamesInvisibleChars,
                 fieldNamesRandom, fieldNamesHomoglyph, fieldNamesInvisibleChars,
-                numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, excludeArea,
-                frame, classRename, methodRename, fieldRename, numberObf, arrayObf, booleanObf, stringObf, debugInfoStrip, classNameLength, methodNameLength, fieldNameLength);
+                numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, flowKeyRandom, excludeArea,
+                frame, classRename, methodRename, fieldRename, numberObf, arrayObf, booleanObf, stringObf, flowObf, debugInfoStrip, classNameLength, methodNameLength, fieldNameLength);
             content.add(step3, STEP_ADVANCED);
 
             // Step 4: Run
             JPanel step4 = buildStep4Panel(inputPath, outputName, outputDir, excludeArea,
-                classRename, methodRename, fieldRename, numberObf, arrayObf, booleanObf, stringObf, debugInfoStrip,
+                classRename, methodRename, fieldRename, numberObf, arrayObf, booleanObf, stringObf, flowObf, debugInfoStrip,
                 classNamesRandom, classNamesHomoglyph, classNamesInvisibleChars,
                 methodNamesRandom, methodNameLength, methodNamesHomoglyph, methodNamesInvisibleChars,
                 fieldNamesRandom, fieldNameLength, fieldNamesHomoglyph, fieldNamesInvisibleChars,
-                numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, classNameLength,
+                numberKeyRandom, arrayKeyRandom, booleanKeyRandom, stringKeyRandom, flowKeyRandom, classNameLength,
                 frame, outputPane);
             content.add(step4, STEP_RUN);
 
@@ -352,7 +354,7 @@ public final class ObfuscatorGui {
     }
 
     private static JPanel buildStep2Panel(JCheckBox classRename, JCheckBox methodRename, JCheckBox fieldRename, JCheckBox numberObf, JCheckBox arrayObf,
-            JCheckBox booleanObf, JCheckBox stringObf, JCheckBox debugInfoStrip, JSpinner classNameLength, JSpinner methodNameLength, JSpinner fieldNameLength) {
+            JCheckBox booleanObf, JCheckBox stringObf, JCheckBox flowObf, JCheckBox debugInfoStrip, JSpinner classNameLength, JSpinner methodNameLength, JSpinner fieldNameLength) {
         JPanel step = new JPanel(new BorderLayout(8, 8));
         step.setBackground(BG_MAIN);
         step.setName(STEP_OBFUSCATION);
@@ -384,6 +386,7 @@ public final class ObfuscatorGui {
         grid.add(arrayObf);
         grid.add(booleanObf);
         grid.add(stringObf);
+        grid.add(flowObf);
         grid.add(debugInfoStrip);
         inner.add(grid, BorderLayout.CENTER);
 
@@ -449,9 +452,9 @@ public final class ObfuscatorGui {
     private static JPanel buildStep3Panel(JCheckBox classNamesRandom, JCheckBox classNamesHomoglyph, JCheckBox classNamesInvisibleChars,
             JCheckBox methodNamesRandom, JCheckBox methodNamesHomoglyph, JCheckBox methodNamesInvisibleChars,
             JCheckBox fieldNamesRandom, JCheckBox fieldNamesHomoglyph, JCheckBox fieldNamesInvisibleChars,
-            JCheckBox numberKeyRandom, JCheckBox arrayKeyRandom, JCheckBox booleanKeyRandom, JCheckBox stringKeyRandom,
+            JCheckBox numberKeyRandom, JCheckBox arrayKeyRandom, JCheckBox booleanKeyRandom, JCheckBox stringKeyRandom, JCheckBox flowKeyRandom,
             JTextArea excludeArea, JFrame frame,
-            JCheckBox classRename, JCheckBox methodRename, JCheckBox fieldRename, JCheckBox numberObf, JCheckBox arrayObf, JCheckBox booleanObf, JCheckBox stringObf,
+            JCheckBox classRename, JCheckBox methodRename, JCheckBox fieldRename, JCheckBox numberObf, JCheckBox arrayObf, JCheckBox booleanObf, JCheckBox stringObf, JCheckBox flowObf,
             JCheckBox debugInfoStrip, JSpinner classNameLength, JSpinner methodNameLength, JSpinner fieldNameLength) {
         JPanel step = new JPanel(new BorderLayout(8, 8));
         step.setBackground(BG_MAIN);
@@ -606,10 +609,10 @@ public final class ObfuscatorGui {
 
     private static JPanel buildStep4Panel(JTextField inputPath, JTextField outputName, JTextField outputDir, JTextArea excludeArea,
             JCheckBox classRename, JCheckBox methodRename, JCheckBox fieldRename, JCheckBox numberObf, JCheckBox arrayObf, JCheckBox booleanObf, JCheckBox stringObf,
-            JCheckBox debugInfoStrip, JCheckBox classNamesRandom, JCheckBox classNamesHomoglyph, JCheckBox classNamesInvisibleChars,
+            JCheckBox flowObf, JCheckBox debugInfoStrip, JCheckBox classNamesRandom, JCheckBox classNamesHomoglyph, JCheckBox classNamesInvisibleChars,
             JCheckBox methodNamesRandom, JSpinner methodNameLength, JCheckBox methodNamesHomoglyph, JCheckBox methodNamesInvisibleChars,
             JCheckBox fieldNamesRandom, JSpinner fieldNameLength, JCheckBox fieldNamesHomoglyph, JCheckBox fieldNamesInvisibleChars,
-            JCheckBox numberKeyRandom, JCheckBox arrayKeyRandom, JCheckBox booleanKeyRandom, JCheckBox stringKeyRandom,
+            JCheckBox numberKeyRandom, JCheckBox arrayKeyRandom, JCheckBox booleanKeyRandom, JCheckBox stringKeyRandom, JCheckBox flowKeyRandom,
             JSpinner classNameLength, JFrame frame, JTextPane outputPane) {
         JPanel step = new JPanel(new BorderLayout(8, 8));
         step.setBackground(BG_MAIN);
@@ -691,6 +694,7 @@ public final class ObfuscatorGui {
                 arrayObf.isSelected(),
                 booleanObf.isSelected(),
                 stringObf.isSelected(),
+                flowObf.isSelected(),
                 debugInfoStrip.isSelected(),
                 classNamesRandom.isSelected(),
                 (Integer) classNameLength.getValue(),
@@ -708,6 +712,7 @@ public final class ObfuscatorGui {
                 arrayKeyRandom.isSelected(),
                 booleanKeyRandom.isSelected(),
                 stringKeyRandom.isSelected(),
+                flowKeyRandom.isSelected(),
                 excludeList
             );
 

--- a/src/main/java/st3ix/obfuscator/log/Logger.java
+++ b/src/main/java/st3ix/obfuscator/log/Logger.java
@@ -31,46 +31,46 @@ public final class Logger {
     }
 
     public static void step(String message) {
-        log("STEP", message, "\033[96m\033[1m");
+        log("STEP", message, "\033[1;33m");
     }
 
     public static void step(String format, Object... args) {
-        log("STEP", String.format(format, args), "\033[96m\033[1m");
+        log("STEP", String.format(format, args), "\033[1;33m");
     }
 
     public static void success(String message) {
-        log("OK", message, "\033[92m");
+        log("OK", message, "\033[32m");
     }
 
     public static void success(String format, Object... args) {
-        log("OK", String.format(format, args), "\033[92m");
+        log("OK", String.format(format, args), "\033[32m");
     }
 
     public static void warn(String message) {
-        log("WARN", message, "\033[33m\033[1m");
+        log("WARN", message, "\033[1;31m");
     }
 
     public static void warn(String format, Object... args) {
-        log("WARN", String.format(format, args), "\033[33m\033[1m");
+        log("WARN", String.format(format, args), "\033[1;31m");
     }
 
     public static void error(String message) {
-        log("ERROR", message, "\033[31m\033[1m");
+        log("ERROR", message, "\033[1;31m");
     }
 
     /** Flow obfuscation: method was flattened into switch-dispatcher (success). */
     public static void flowFlattened(String format, Object... args) {
-        log("FLOW", String.format(format, args), "\033[92m\033[1m");
+        log("FLOW", String.format(format, args), "\033[1;32m");
     }
 
     /** Flow obfuscation: method was skipped (e.g. unsupported control flow, too few blocks). */
     public static void flowSkipped(String format, Object... args) {
-        log("SKIP", String.format(format, args), "\033[95m");
+        log("SKIP", String.format(format, args), "\033[2;37m");
     }
 
     /** Flow obfuscation: transform progress (class being processed). */
     public static void flowTransform(String format, Object... args) {
-        log("FLOW", String.format(format, args), "\033[96m");
+        log("FLOW", String.format(format, args), "\033[36m");
     }
 
     private static void log(String level, String message, String color) {

--- a/src/main/java/st3ix/obfuscator/log/Logger.java
+++ b/src/main/java/st3ix/obfuscator/log/Logger.java
@@ -23,19 +23,19 @@ public final class Logger {
     }
 
     public static void info(String message) {
-        log("INFO", message, "\033[32m");
+        log("INFO", message, "\033[34m");
     }
 
     public static void info(String format, Object... args) {
-        log("INFO", String.format(format, args), "\033[32m");
+        log("INFO", String.format(format, args), "\033[34m");
     }
 
     public static void step(String message) {
-        log("STEP", message, "\033[36m");
+        log("STEP", message, "\033[96m\033[1m");
     }
 
     public static void step(String format, Object... args) {
-        log("STEP", String.format(format, args), "\033[36m");
+        log("STEP", String.format(format, args), "\033[96m\033[1m");
     }
 
     public static void success(String message) {
@@ -47,11 +47,30 @@ public final class Logger {
     }
 
     public static void warn(String message) {
-        log("WARN", message, "\033[33m");
+        log("WARN", message, "\033[33m\033[1m");
+    }
+
+    public static void warn(String format, Object... args) {
+        log("WARN", String.format(format, args), "\033[33m\033[1m");
     }
 
     public static void error(String message) {
-        log("ERROR", message, "\033[31m");
+        log("ERROR", message, "\033[31m\033[1m");
+    }
+
+    /** Flow obfuscation: method was flattened into switch-dispatcher (success). */
+    public static void flowFlattened(String format, Object... args) {
+        log("FLOW", String.format(format, args), "\033[92m\033[1m");
+    }
+
+    /** Flow obfuscation: method was skipped (e.g. unsupported control flow, too few blocks). */
+    public static void flowSkipped(String format, Object... args) {
+        log("SKIP", String.format(format, args), "\033[95m");
+    }
+
+    /** Flow obfuscation: transform progress (class being processed). */
+    public static void flowTransform(String format, Object... args) {
+        log("FLOW", String.format(format, args), "\033[96m");
     }
 
     private static void log(String level, String message, String color) {

--- a/src/main/java/st3ix/obfuscator/transform/FlowObfuscator.java
+++ b/src/main/java/st3ix/obfuscator/transform/FlowObfuscator.java
@@ -1,0 +1,438 @@
+package st3ix.obfuscator.transform;
+
+import org.objectweb.asm.Label;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.IntInsnNode;
+import org.objectweb.asm.tree.JumpInsnNode;
+import org.objectweb.asm.tree.LabelNode;
+import org.objectweb.asm.tree.LdcInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.TableSwitchInsnNode;
+import org.objectweb.asm.tree.LookupSwitchInsnNode;
+import org.objectweb.asm.tree.VarInsnNode;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import st3ix.obfuscator.log.Logger;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+/**
+ * Control flow obfuscation via flattening.
+ * Converts method control flow into a switch-dispatcher structure so decompilers
+ * show a flat switch instead of the original branching logic.
+ * Skips constructors, static init, native/abstract methods, and methods with try-catch.
+ */
+public final class FlowObfuscator {
+
+    private static final int DEFAULT_KEY = 0x3B9A7C2E;
+    private static final int MIN_INSTRUCTIONS = 4;
+    private static final int CHUNK_SIZE = 5;
+
+    private final int key;
+
+    public FlowObfuscator() {
+        this.key = DEFAULT_KEY;
+    }
+
+    public static FlowObfuscator withRandomKey() {
+        return new FlowObfuscator(new Random().nextInt());
+    }
+
+    private FlowObfuscator(int key) {
+        this.key = key;
+    }
+
+    public byte[] transform(byte[] classBytes) {
+        ClassNode classNode = new ClassNode();
+        ClassReader reader = new ClassReader(classBytes);
+        reader.accept(classNode, ClassReader.EXPAND_FRAMES);
+
+        for (Object m : classNode.methods) {
+            transformMethod(classNode.name, (MethodNode) m);
+        }
+
+        try {
+            // ClassWriter with ClassReader for getCommonSuperClass - needed for correct frame merge with COMPUTE_FRAMES
+            ClassWriter writer = new ClassWriter(reader, ClassWriter.COMPUTE_FRAMES);
+            classNode.accept(writer);
+            return writer.toByteArray();
+        } catch (Throwable t) {
+            String msg = t.getMessage();
+            if (msg == null) msg = t.getClass().getSimpleName();
+            Logger.warn(String.format("  Flow ClassWriter failed, skipping: %s", msg));
+            return classBytes;
+        }
+    }
+
+    private void transformMethod(String className, MethodNode method) {
+        if ("<init>".equals(method.name) || "<clinit>".equals(method.name)) return;
+        if ((method.access & (Opcodes.ACC_NATIVE | Opcodes.ACC_ABSTRACT)) != 0) return;
+        if (method.tryCatchBlocks != null && !method.tryCatchBlocks.isEmpty()) return;
+        if (method.instructions == null || method.instructions.size() < MIN_INSTRUCTIONS) {
+            Logger.flowSkipped("%s.%s (too few instructions)", className.replace('/', '.'), method.name);
+            return;
+        }
+
+        List<BasicBlock> blocks = buildBasicBlocks(method);
+        if (blocks.size() < 2) {
+            Logger.flowSkipped("%s.%s (only %d block(s))", className.replace('/', '.'), method.name, blocks.size());
+            return;
+        }
+
+        Map<LabelNode, Integer> labelToBlock = new HashMap<>();
+        for (int i = 0; i < blocks.size(); i++) {
+            if (blocks.get(i).startLabel != null) {
+                labelToBlock.put(blocks.get(i).startLabel, i);
+            }
+        }
+
+        Map<Integer, Integer> blockToNext = computeNextBlocks(blocks, labelToBlock);
+        if (blockToNext == null) {
+            Logger.flowSkipped("%s.%s (unsupported control flow)", className.replace('/', '.'), method.name);
+            return;
+        }
+
+        int stateVar = method.maxLocals;
+        if (stateVar <= 0) {
+            stateVar = Type.getArgumentsAndReturnSizes(method.desc) >> 2;
+        }
+        method.maxLocals++;
+
+        InsnList newInsns = new InsnList();
+
+        org.objectweb.asm.tree.LabelNode dispatcherLabelNode = new org.objectweb.asm.tree.LabelNode();
+        List<org.objectweb.asm.tree.LabelNode> blockLabelNodes = new ArrayList<>(blocks.size() + 1);
+        for (int i = 0; i < blocks.size(); i++) {
+            blockLabelNodes.add(new org.objectweb.asm.tree.LabelNode());
+        }
+        org.objectweb.asm.tree.LabelNode exitLabelNode = new org.objectweb.asm.tree.LabelNode();
+
+        int firstObfState = obfuscateState(0);
+        emitConst(newInsns, firstObfState);
+        newInsns.add(new VarInsnNode(Opcodes.ISTORE, stateVar));
+
+        newInsns.add(dispatcherLabelNode);
+        newInsns.add(new VarInsnNode(Opcodes.ILOAD, stateVar));
+        newInsns.add(new LdcInsnNode(key));
+        newInsns.add(new InsnNode(Opcodes.IXOR));
+
+        org.objectweb.asm.tree.LabelNode[] switchLabels = new org.objectweb.asm.tree.LabelNode[blocks.size() + 1];
+        for (int i = 0; i < blocks.size(); i++) {
+            switchLabels[i] = blockLabelNodes.get(i);
+        }
+        switchLabels[blocks.size()] = exitLabelNode;
+
+        newInsns.add(new TableSwitchInsnNode(0, blocks.size(), exitLabelNode, switchLabels));
+
+        for (int i = 0; i < blocks.size(); i++) {
+            BasicBlock block = blocks.get(i);
+            newInsns.add(blockLabelNodes.get(i));
+
+            Integer next = blockToNext.get(i);
+            AbstractInsnNode lastInBlock = block.instructions.isEmpty() ? null : block.instructions.get(block.instructions.size() - 1);
+            boolean excludeLast = (next == null) || (next != null && lastInBlock instanceof JumpInsnNode jmp && jmp.getOpcode() == Opcodes.GOTO);
+            copyBlockContent(newInsns, block, excludeLast);
+
+            if (next != null) {
+                int nextObf = obfuscateState(next);
+                emitConst(newInsns, nextObf);
+                newInsns.add(new VarInsnNode(Opcodes.ISTORE, stateVar));
+                newInsns.add(new JumpInsnNode(Opcodes.GOTO, dispatcherLabelNode));
+            } else {
+                AbstractInsnNode term = block.instructions.get(block.instructions.size() - 1);
+                // Skip cloning label-referencing instructions - clone(emptyMap) can return null or invalid node
+                if (term instanceof JumpInsnNode || term instanceof TableSwitchInsnNode || term instanceof LookupSwitchInsnNode) continue;
+                AbstractInsnNode cloned = term.clone(new HashMap<>());
+                if (cloned != null) newInsns.add(cloned);
+            }
+        }
+
+        newInsns.add(exitLabelNode);
+        newInsns.add(new InsnNode(Opcodes.RETURN));
+
+        method.instructions.clear();
+        // Transfer node-by-node to avoid NPE in InsnList.add(InsnList) with complex structures
+        AbstractInsnNode cursor = newInsns.getFirst();
+        while (cursor != null) {
+            AbstractInsnNode next = cursor.getNext();
+            newInsns.remove(cursor);
+            method.instructions.add(cursor);
+            cursor = next;
+        }
+        // Clear stale debug info (references old labels) - avoids ClassWriter "Index 0 out of bounds"
+        method.localVariables = null;
+        method.parameters = null;
+        Logger.flowFlattened("%s.%s (%d blocks)", className.replace('/', '.'), method.name, blocks.size());
+    }
+
+    private boolean returns(BasicBlock block) {
+        if (block.instructions.isEmpty()) return false;
+        AbstractInsnNode last = block.instructions.get(block.instructions.size() - 1);
+        int op = last.getOpcode();
+        return op == Opcodes.RETURN || op == Opcodes.ARETURN || op == Opcodes.IRETURN
+            || op == Opcodes.LRETURN || op == Opcodes.FRETURN || op == Opcodes.DRETURN
+            || op == Opcodes.ATHROW;
+    }
+
+    private void emitConst(InsnList list, int value) {
+        if (value >= -1 && value <= 5) {
+            int op = value == -1 ? Opcodes.ICONST_M1 :
+                value == 0 ? Opcodes.ICONST_0 : value == 1 ? Opcodes.ICONST_1 :
+                value == 2 ? Opcodes.ICONST_2 : value == 3 ? Opcodes.ICONST_3 :
+                value == 4 ? Opcodes.ICONST_4 : Opcodes.ICONST_5;
+            list.add(new InsnNode(op));
+        } else if (value >= Byte.MIN_VALUE && value <= Byte.MAX_VALUE) {
+            list.add(new IntInsnNode(Opcodes.BIPUSH, value));
+        } else {
+            list.add(new LdcInsnNode(value));
+        }
+    }
+
+    private int obfuscateState(int state) {
+        return state ^ key;
+    }
+
+    private static final Map<LabelNode, LabelNode> EMPTY_LABEL_MAP = Map.of();
+
+    private void copyBlockContent(InsnList dest, BasicBlock block, boolean excludeLast) {
+        int end = excludeLast ? block.instructions.size() - 1 : block.instructions.size();
+        for (int i = 0; i < end; i++) {
+            AbstractInsnNode insn = block.instructions.get(i);
+            if (insn instanceof LabelNode || insn instanceof org.objectweb.asm.tree.LineNumberNode) continue;
+            if (insn instanceof org.objectweb.asm.tree.FrameNode) continue;
+            // Skip instructions that reference labels - ASM clone(map) needs map when labels are used
+            if (insn instanceof JumpInsnNode || insn instanceof TableSwitchInsnNode || insn instanceof LookupSwitchInsnNode) continue;
+            AbstractInsnNode cloned = insn.clone(EMPTY_LABEL_MAP);
+            if (cloned != null) dest.add(cloned);
+        }
+    }
+
+    private Map<Integer, Integer> computeNextBlocks(List<BasicBlock> blocks, Map<LabelNode, Integer> labelToBlock) {
+        Map<Integer, Integer> next = new HashMap<>();
+        for (int i = 0; i < blocks.size(); i++) {
+            BasicBlock block = blocks.get(i);
+            AbstractInsnNode last = block.instructions.get(block.instructions.size() - 1);
+            if (isConditionalBranch(last)) {
+                return null;
+            }
+            if (isTerminator(last)) {
+                if (last instanceof JumpInsnNode) {
+                    JumpInsnNode jmp = (JumpInsnNode) last;
+                    if (jmp.getOpcode() != Opcodes.GOTO) return null;
+                    LabelNode target = jmp.label;
+                    Integer targetBlock = labelToBlock.get(target);
+                    if (targetBlock != null) {
+                        next.put(i, targetBlock);
+                    }
+                } else if (last instanceof TableSwitchInsnNode) {
+                    return null;
+                } else if (last instanceof LookupSwitchInsnNode) {
+                    return null;
+                }
+            } else if (i + 1 < blocks.size()) {
+                next.put(i, i + 1);
+            }
+        }
+        // Reject methods with back-edges (loops) - COMPUTE_FRAMES produces invalid stack maps for them
+        for (int i = 0; i < blocks.size(); i++) {
+            Integer target = next.get(i);
+            if (target != null && target <= i) {
+                return null; // back-edge = loop, skip
+            }
+        }
+        return next;
+    }
+
+    private boolean isConditionalBranch(AbstractInsnNode insn) {
+        if (insn == null) return false;
+        int op = insn.getOpcode();
+        return op == Opcodes.IFEQ || op == Opcodes.IFNE || op == Opcodes.IFLT || op == Opcodes.IFGE
+            || op == Opcodes.IFGT || op == Opcodes.IFLE || op == Opcodes.IF_ICMPEQ || op == Opcodes.IF_ICMPNE
+            || op == Opcodes.IF_ICMPLT || op == Opcodes.IF_ICMPGE || op == Opcodes.IF_ICMPGT || op == Opcodes.IF_ICMPLE
+            || op == Opcodes.IF_ACMPEQ || op == Opcodes.IF_ACMPNE || op == Opcodes.IFNULL || op == Opcodes.IFNONNULL
+            || insn instanceof TableSwitchInsnNode || insn instanceof LookupSwitchInsnNode;
+    }
+
+    private boolean isTerminator(AbstractInsnNode insn) {
+        if (insn == null) return false;
+        switch (insn.getOpcode()) {
+            case Opcodes.RETURN:
+            case Opcodes.ARETURN:
+            case Opcodes.IRETURN:
+            case Opcodes.LRETURN:
+            case Opcodes.FRETURN:
+            case Opcodes.DRETURN:
+            case Opcodes.ATHROW:
+                return true;
+            case Opcodes.GOTO:
+            case Opcodes.IFEQ: case Opcodes.IFNE: case Opcodes.IFLT: case Opcodes.IFGE:
+            case Opcodes.IFGT: case Opcodes.IFLE: case Opcodes.IF_ICMPEQ: case Opcodes.IF_ICMPNE:
+            case Opcodes.IF_ICMPLT: case Opcodes.IF_ICMPGE: case Opcodes.IF_ICMPGT: case Opcodes.IF_ICMPLE:
+            case Opcodes.IF_ACMPEQ: case Opcodes.IF_ACMPNE:
+            case Opcodes.IFNULL: case Opcodes.IFNONNULL:
+                return true;
+            default:
+                return insn instanceof TableSwitchInsnNode || insn instanceof LookupSwitchInsnNode;
+        }
+    }
+
+    private List<BasicBlock> buildBasicBlocks(MethodNode method) {
+        Set<LabelNode> branchTargets = new HashSet<>();
+        AbstractInsnNode first = method.instructions.getFirst();
+        if (first instanceof LabelNode) {
+            branchTargets.add((LabelNode) first);
+        }
+
+        for (AbstractInsnNode insn : method.instructions) {
+            if (insn instanceof JumpInsnNode) {
+                branchTargets.add(((JumpInsnNode) insn).label);
+            } else if (insn instanceof TableSwitchInsnNode) {
+                TableSwitchInsnNode ts = (TableSwitchInsnNode) insn;
+                branchTargets.add(ts.dflt);
+                for (Object l : ts.labels) branchTargets.add((LabelNode) l);
+            } else if (insn instanceof LookupSwitchInsnNode) {
+                LookupSwitchInsnNode ls = (LookupSwitchInsnNode) insn;
+                branchTargets.add(ls.dflt);
+                for (Object l : ls.labels) branchTargets.add((LabelNode) l);
+            }
+        }
+
+        List<BasicBlock> blocks = new ArrayList<>();
+        BasicBlock current = null;
+
+        for (AbstractInsnNode insn : method.instructions) {
+            if (insn instanceof LabelNode && branchTargets.contains(insn)) {
+                if (current != null && !current.instructions.isEmpty()) {
+                    blocks.add(current);
+                }
+                current = new BasicBlock((LabelNode) insn);
+            }
+            if (current == null) {
+                current = new BasicBlock(null);
+            }
+            current.instructions.add(insn);
+        }
+        if (current != null) blocks.add(current);
+
+        // Linear methods (no branches) yield only 1 block - split artificially into chunks
+        if (blocks.size() == 1) {
+            blocks = splitLinearBlock(blocks.get(0));
+        }
+
+        return blocks;
+    }
+
+    private List<BasicBlock> splitLinearBlock(BasicBlock single) {
+        List<AbstractInsnNode> real = new ArrayList<>();
+        for (AbstractInsnNode insn : single.instructions) {
+            if (insn instanceof LabelNode || insn instanceof org.objectweb.asm.tree.LineNumberNode)
+                continue;
+            if (insn instanceof org.objectweb.asm.tree.FrameNode) continue;
+            real.add(insn);
+        }
+        if (real.size() < 4) return java.util.Collections.singletonList(single);
+
+        // Find split points where stack is empty - required for valid bytecode (each block must
+        // reach the dispatcher GOTO with empty stack, otherwise COMPUTE_FRAMES fails)
+        List<Integer> splitIndices = new ArrayList<>();
+        splitIndices.add(0);
+        int stack = 0;
+        for (int i = 0; i < real.size(); i++) {
+            stack += stackDelta(real.get(i));
+            if (stack == 0 && i + 1 < real.size() && splitIndices.size() < 32) {
+                int lastSplit = splitIndices.get(splitIndices.size() - 1);
+                if (i - lastSplit >= 1) splitIndices.add(i + 1);
+            }
+        }
+        if (stack != 0 || splitIndices.size() < 2) return java.util.Collections.singletonList(single);
+        splitIndices.add(real.size());
+
+        List<BasicBlock> chunks = new ArrayList<>();
+        for (int s = 0; s < splitIndices.size() - 1; s++) {
+            BasicBlock chunk = new BasicBlock(null);
+            for (int i = splitIndices.get(s); i < splitIndices.get(s + 1); i++) {
+                chunk.instructions.add(real.get(i));
+            }
+            chunks.add(chunk);
+        }
+        return chunks.size() >= 2 ? chunks : java.util.Collections.singletonList(single);
+    }
+
+    /** Stack delta (pops negative, pushes positive) for finding stack-neutral split points. */
+    private static int stackDelta(AbstractInsnNode insn) {
+        if (insn == null) return 0;
+        int op = insn.getOpcode();
+        switch (op) {
+            case Opcodes.NOP: case Opcodes.GOTO: case Opcodes.RETURN:
+            case Opcodes.IFEQ: case Opcodes.IFNE: case Opcodes.IFLT: case Opcodes.IFGE:
+            case Opcodes.IFGT: case Opcodes.IFLE: case Opcodes.IF_ICMPEQ: case Opcodes.IF_ICMPNE:
+            case Opcodes.IF_ICMPLT: case Opcodes.IF_ICMPGE: case Opcodes.IF_ICMPGT: case Opcodes.IF_ICMPLE:
+            case Opcodes.IF_ACMPEQ: case Opcodes.IF_ACMPNE: case Opcodes.IFNULL: case Opcodes.IFNONNULL:
+            case Opcodes.MONITORENTER: case Opcodes.MONITOREXIT: case Opcodes.SWAP:
+                return 0;
+            case Opcodes.IRETURN: case Opcodes.FRETURN: case Opcodes.ARETURN:
+            case Opcodes.ISTORE: case Opcodes.FSTORE: case Opcodes.ASTORE: case Opcodes.POP:
+            case Opcodes.ATHROW:
+                return -1;
+            case Opcodes.LRETURN: case Opcodes.DRETURN:
+            case Opcodes.LSTORE: case Opcodes.DSTORE: case Opcodes.POP2:
+                return -2;
+            case Opcodes.ICONST_M1: case Opcodes.ICONST_0: case Opcodes.ICONST_1: case Opcodes.ICONST_2:
+            case Opcodes.ICONST_3: case Opcodes.ICONST_4: case Opcodes.ICONST_5:
+            case Opcodes.FCONST_0: case Opcodes.FCONST_1: case Opcodes.FCONST_2:
+            case Opcodes.ACONST_NULL: case Opcodes.ILOAD: case Opcodes.FLOAD: case Opcodes.ALOAD:
+            case Opcodes.BIPUSH: case Opcodes.SIPUSH:
+                return 1;
+            case Opcodes.LCONST_0: case Opcodes.LCONST_1: case Opcodes.DCONST_0: case Opcodes.DCONST_1:
+            case Opcodes.LLOAD: case Opcodes.DLOAD:
+                return 2;
+            case Opcodes.LDC:
+                return (insn instanceof org.objectweb.asm.tree.LdcInsnNode ldc
+                    && (ldc.cst instanceof Long || ldc.cst instanceof Double)) ? 2 : 1;
+            case Opcodes.DUP: return 1;
+            case Opcodes.DUP2: return 2;
+            case Opcodes.IADD: case Opcodes.ISUB: case Opcodes.IMUL: case Opcodes.IDIV: case Opcodes.IREM:
+            case Opcodes.IAND: case Opcodes.IOR: case Opcodes.IXOR: case Opcodes.ISHL: case Opcodes.ISHR:
+            case Opcodes.IUSHR: case Opcodes.L2I: case Opcodes.I2L: case Opcodes.I2F: case Opcodes.I2D:
+            case Opcodes.L2F: case Opcodes.L2D: case Opcodes.F2I: case Opcodes.F2L: case Opcodes.F2D:
+            case Opcodes.D2I: case Opcodes.D2L: case Opcodes.D2F: case Opcodes.LCMP: case Opcodes.INEG:
+            case Opcodes.I2B: case Opcodes.I2C: case Opcodes.I2S: case Opcodes.ARRAYLENGTH:
+                return -1;
+            case Opcodes.LADD: case Opcodes.LSUB: case Opcodes.LMUL: case Opcodes.LDIV: case Opcodes.LREM:
+                return -2;
+            case Opcodes.IALOAD: case Opcodes.LALOAD: case Opcodes.FALOAD: case Opcodes.DALOAD:
+            case Opcodes.AALOAD: case Opcodes.BALOAD: case Opcodes.CALOAD: case Opcodes.SALOAD:
+                return -1;
+            default:
+                if (op >= Opcodes.INVOKEVIRTUAL && op <= Opcodes.INVOKEDYNAMIC && insn instanceof org.objectweb.asm.tree.MethodInsnNode mi) {
+                    int retSize = Type.getReturnType(mi.desc).getSize();
+                    int argSize = Type.getArgumentTypes(mi.desc).length;
+                    if (op != Opcodes.INVOKESTATIC && op != Opcodes.INVOKEDYNAMIC) argSize++;
+                    return retSize - argSize;
+                }
+                if (op == Opcodes.NEW || op == Opcodes.GETSTATIC || op == Opcodes.GETFIELD) return 1;
+                if (op == Opcodes.PUTSTATIC || op == Opcodes.PUTFIELD) return -1;
+                return 0;
+        }
+    }
+
+    private static final class BasicBlock {
+        final LabelNode startLabel;
+        final List<AbstractInsnNode> instructions = new ArrayList<>();
+
+        BasicBlock(LabelNode startLabel) {
+            this.startLabel = startLabel;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Flow obfuscation for linear methods (switch-dispatcher structure)
- Improved Logger colors for STEP, INFO, and Flow messages

## Changes

### Flow obfuscation
- Control flow flattening via switch-dispatcher
- Only linear methods (no loops, no conditionals)
- Stack-aware splitting at stack-neutral boundaries
- Back-edge detection to avoid VerifyError

### Logger
- STEP: bright cyan, bold
- INFO: blue (distinct from STEP)
- Flow flattened: bright green
- Flow skipped: magenta
- Flow transform: cyan

### Example project
- Linear methods for Flow obfuscation demo in StringHelper, User, DemoService
- formatIdLinear, toDisplayString, computeHash

## Testing
- Obfuscation with flow obfuscation enabled
- Obfuscated JAR runs without VerifyError
- Log output visually verified

Closes #43, #42 